### PR TITLE
deploy: Phase 1 — new Profile dashboard

### DIFF
--- a/components/profile/AccountList.js
+++ b/components/profile/AccountList.js
@@ -1,0 +1,68 @@
+import { ChevronRight, CreditCard, Hammer, Heart, LogOut, MessageCircle, Package } from "lucide-react";
+import Link from "next/link";
+
+const ICONS = { Package, CreditCard, Hammer, Heart, MessageCircle, LogOut };
+const ICON_PROPS = { size: 18, strokeWidth: 1.5 };
+
+const ROW_CLASS =
+  "flex items-center justify-between w-full py-4 border-b border-wedsy-rose-100/50 hover:bg-wedsy-rose-50 transition-colors text-left";
+
+function RowContent({ item }) {
+  const Icon = item.iconName ? ICONS[item.iconName] : null;
+  return (
+    <>
+      <span className="flex items-center gap-3 text-[15px] text-wedsy-ink-2">
+        {Icon && <Icon {...ICON_PROPS} className="text-wedsy-ink-3" />}
+        {item.label}
+      </span>
+      <span className="flex items-center gap-2">
+        {item.badge && (
+          <span className="text-[10px] tracking-[1px] uppercase font-medium bg-wedsy-rose-600 text-white px-2 py-0.5">
+            {item.badge}
+          </span>
+        )}
+        <ChevronRight {...ICON_PROPS} className="text-wedsy-ink-3" />
+      </span>
+    </>
+  );
+}
+
+export default function AccountList({ items = [], onSignOut }) {
+  return (
+    <section className="pt-2 pb-12 px-6">
+      <p className="wedsy-eyebrow">ACCOUNT</p>
+      <h2 className="wedsy-title text-[24px] mt-2 text-wedsy-ink">Manage your wedding</h2>
+      <p className="wedsy-italic-em text-[14px] mt-1">Everything you&apos;ve shared with us</p>
+      <div className="wedsy-ornament-divider my-6 mx-auto"></div>
+
+      <ul>
+        {items.map((item, i) =>
+          item.href ? (
+            <li key={i}>
+              <Link href={item.href} className={ROW_CLASS} onClick={item.onTap}>
+                <RowContent item={item} />
+              </Link>
+            </li>
+          ) : (
+            <li key={i}>
+              <button type="button" onClick={item.onTap} className={ROW_CLASS}>
+                <RowContent item={item} />
+              </button>
+            </li>
+          )
+        )}
+
+        <li>
+          <button
+            type="button"
+            onClick={onSignOut}
+            className="flex items-center gap-3 w-full py-4 mt-2 text-[15px] text-wedsy-burgundy-soft hover:bg-wedsy-rose-50 transition-colors text-left"
+          >
+            <LogOut {...ICON_PROPS} />
+            Sign Out
+          </button>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/components/profile/EmptyStateStep1.js
+++ b/components/profile/EmptyStateStep1.js
@@ -1,0 +1,80 @@
+import { useState } from "react";
+
+const COMMUNITIES = ["Hindu", "Muslim", "Christian", "Sikh", "Jain", "Jewish", "Other"];
+
+export default function EmptyStateStep1({ onContinue }) {
+  const [eventName, setEventName] = useState("");
+  const [community, setCommunity] = useState("");
+
+  const canContinue = eventName.trim().length > 0 && community.length > 0;
+
+  const handleContinue = () => {
+    if (!canContinue) return;
+    onContinue({ eventName: eventName.trim(), community });
+  };
+
+  return (
+    <section className="text-center pt-12 pb-10 px-6">
+      <p className="wedsy-eyebrow">STEP 1 OF 2</p>
+      <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink">
+        Tell us about your wedding
+      </h1>
+      <p className="wedsy-italic-em text-[15px] mt-2">
+        We&apos;ll build your dashboard around this
+      </p>
+      <div className="wedsy-ornament-divider my-6 mx-auto"></div>
+
+      <div className="text-left mt-8 space-y-6">
+        <div>
+          <label
+            htmlFor="profile-event-name"
+            className="block text-[11px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium mb-2"
+          >
+            What should we call this celebration?
+          </label>
+          <input
+            id="profile-event-name"
+            type="text"
+            value={eventName}
+            onChange={(e) => setEventName(e.target.value)}
+            placeholder="e.g., Rohaan & Asiya"
+            className="w-full bg-wedsy-ivory-2 border border-wedsy-rose-100 px-4 py-3 text-wedsy-ink placeholder:font-serif placeholder:italic placeholder:text-wedsy-ink-3 focus:outline-none focus:border-wedsy-burgundy-soft transition-colors"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="profile-community"
+            className="block text-[11px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium mb-2"
+          >
+            Community
+          </label>
+          <select
+            id="profile-community"
+            value={community}
+            onChange={(e) => setCommunity(e.target.value)}
+            className="w-full bg-wedsy-ivory-2 border border-wedsy-rose-100 px-4 py-3 text-wedsy-ink focus:outline-none focus:border-wedsy-burgundy-soft transition-colors appearance-none"
+          >
+            <option value="" disabled>
+              Select community…
+            </option>
+            {COMMUNITIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        disabled={!canContinue}
+        onClick={handleContinue}
+        className="mt-10 w-full py-3 bg-wedsy-rose-600 text-white text-[13px] tracking-[2px] uppercase font-medium disabled:bg-wedsy-ink-3 disabled:cursor-not-allowed transition-colors"
+      >
+        Continue
+      </button>
+    </section>
+  );
+}

--- a/components/profile/EmptyStateStep2.js
+++ b/components/profile/EmptyStateStep2.js
@@ -1,0 +1,133 @@
+import { useState } from "react";
+
+const blankDay = () => ({ name: "", date: "", time: "", venue: "" });
+
+const fieldClass =
+  "w-full bg-transparent border-b border-wedsy-rose-100 px-0 py-2 text-wedsy-ink placeholder:font-serif placeholder:italic placeholder:text-wedsy-ink-3 focus:outline-none focus:border-wedsy-burgundy-soft transition-colors";
+
+export default function EmptyStateStep2({ eventName, community, onBack, onComplete }) {
+  const [sameVenue, setSameVenue] = useState(true);
+  const [commonVenue, setCommonVenue] = useState("");
+  const [eventDays, setEventDays] = useState([blankDay()]);
+
+  const updateDay = (idx, patch) =>
+    setEventDays((days) => days.map((d, i) => (i === idx ? { ...d, ...patch } : d)));
+  const addDay = () => setEventDays((days) => [...days, blankDay()]);
+  const removeDay = (idx) =>
+    setEventDays((days) => (days.length > 1 ? days.filter((_, i) => i !== idx) : days));
+
+  const isValid = (() => {
+    if (!eventDays.every((d) => d.name.trim() && d.date)) return false;
+    if (sameVenue) return commonVenue.trim().length > 0;
+    return eventDays.every((d) => d.venue.trim().length > 0);
+  })();
+
+  const handleCreate = () => {
+    if (!isValid) return;
+    const finalDays = sameVenue
+      ? eventDays.map((d) => ({ ...d, venue: commonVenue.trim() }))
+      : eventDays;
+    onComplete({ eventDays: finalDays });
+  };
+
+  return (
+    <section className="pt-12 pb-10 px-6">
+      <div className="text-center">
+        <p className="wedsy-eyebrow">STEP 2 OF 2</p>
+        <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink">Your celebration days</h1>
+        <p className="wedsy-italic-em text-[15px] mt-2">Add each event of your wedding</p>
+        <div className="wedsy-ornament-divider my-6 mx-auto"></div>
+        <p className="text-[12px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium">{eventName} · {community}</p>
+      </div>
+
+      <div className="mt-8 flex items-center justify-between">
+        <span className="text-[13px] text-wedsy-ink-2">Same venue for all events?</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={sameVenue}
+          onClick={() => setSameVenue((v) => !v)}
+          className={`relative inline-flex h-6 w-11 items-center transition-colors ${sameVenue ? "bg-wedsy-rose-600" : "bg-wedsy-ink-3"}`}
+        >
+          <span className={`inline-block h-5 w-5 transform bg-white transition-transform ${sameVenue ? "translate-x-[22px]" : "translate-x-0.5"}`} />
+        </button>
+      </div>
+
+      {sameVenue && (
+        <div className="mt-6">
+          <label htmlFor="profile-common-venue" className="block text-[11px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium mb-2">Common venue</label>
+          <input
+            id="profile-common-venue"
+            type="text"
+            value={commonVenue}
+            onChange={(e) => setCommonVenue(e.target.value)}
+            placeholder="e.g., The Leela Palace, Bangalore"
+            className="w-full bg-wedsy-ivory-2 border border-wedsy-rose-100 px-4 py-3 text-wedsy-ink placeholder:font-serif placeholder:italic placeholder:text-wedsy-ink-3 focus:outline-none focus:border-wedsy-burgundy-soft transition-colors"
+          />
+        </div>
+      )}
+
+      <div className="mt-6 space-y-4">
+        {eventDays.map((day, idx) => (
+          <div key={idx} className="relative bg-wedsy-ivory-2 border border-wedsy-rose-100 p-4">
+            <button
+              type="button"
+              disabled={eventDays.length === 1}
+              onClick={() => removeDay(idx)}
+              aria-label="Remove day"
+              className="absolute top-2 right-2 w-6 h-6 flex items-center justify-center text-wedsy-ink-3 text-lg leading-none disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              ×
+            </button>
+            <input
+              type="text"
+              value={day.name}
+              onChange={(e) => updateDay(idx, { name: e.target.value })}
+              placeholder="e.g., Mehendi"
+              className={fieldClass}
+            />
+            <div className="mt-3 flex gap-3">
+              <input type="date" value={day.date} onChange={(e) => updateDay(idx, { date: e.target.value })} className={`${fieldClass} flex-1 text-[13px]`} />
+              <input type="time" value={day.time} onChange={(e) => updateDay(idx, { time: e.target.value })} className={`${fieldClass} flex-1 text-[13px]`} />
+            </div>
+            {!sameVenue && (
+              <input
+                type="text"
+                value={day.venue}
+                onChange={(e) => updateDay(idx, { venue: e.target.value })}
+                placeholder="Venue for this day"
+                className={`${fieldClass} mt-3 text-[13px]`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={addDay}
+        className="mt-4 w-full py-2 border border-wedsy-rose-400 text-wedsy-rose-600 text-[12px] tracking-[1px] uppercase font-medium hover:bg-wedsy-rose-50 transition-colors"
+      >
+        + Add another day
+      </button>
+
+      <div className="mt-10 flex gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex-1 py-3 border border-wedsy-rose-400 text-wedsy-rose-600 text-[13px] tracking-[2px] uppercase font-medium hover:bg-wedsy-rose-50 transition-colors"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          disabled={!isValid}
+          onClick={handleCreate}
+          className="flex-1 py-3 bg-wedsy-rose-600 text-white text-[13px] tracking-[2px] uppercase font-medium disabled:bg-wedsy-ink-3 disabled:cursor-not-allowed transition-colors"
+        >
+          Create
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/profile/EventDaysCarousel.js
+++ b/components/profile/EventDaysCarousel.js
@@ -1,0 +1,49 @@
+function formatDay(isoDate) {
+  const d = new Date(isoDate);
+  const weekday = d.toLocaleString("en-GB", { weekday: "long" });
+  const day = d.getDate();
+  const month = d.toLocaleString("en-GB", { month: "short" });
+  return `${weekday}, ${day} ${month}`;
+}
+
+const SPELLED = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"];
+const spell = (n) => (n < SPELLED.length ? SPELLED[n] : String(n));
+
+export default function EventDaysCarousel({ eventDays = [] }) {
+  const heading =
+    eventDays.length === 1
+      ? "One day of celebration"
+      : `${spell(eventDays.length)} days of celebration`;
+
+  return (
+    <section className="pt-2 pb-8 px-0">
+      <p className="wedsy-eyebrow px-6">YOUR EVENTS</p>
+      <h2 className="wedsy-title text-[24px] mt-2 text-wedsy-ink px-6">{heading}</h2>
+
+      <div className="mt-5 flex gap-3 overflow-x-auto scrollbar-hide px-6">
+        {eventDays.length === 0 ? (
+          <div className="w-[260px] shrink-0 bg-wedsy-ivory-2 border border-wedsy-rose-100 p-5">
+            <p className="wedsy-italic-em text-[13px] text-wedsy-ink-3 text-center">
+              Add your event days to see them here
+            </p>
+          </div>
+        ) : (
+          eventDays.map((day, i) => (
+            <article
+              key={i}
+              className="w-[260px] shrink-0 bg-wedsy-ivory-2 border border-wedsy-rose-100 p-5"
+            >
+              <p className="text-[10px] tracking-[1px] uppercase font-medium text-wedsy-rose-600">
+                Day {i + 1}
+              </p>
+              <h3 className="wedsy-title text-[20px] mt-1 text-wedsy-ink">{day.name}</h3>
+              <p className="text-[13px] mt-2 text-wedsy-ink-2">{formatDay(day.date)}</p>
+              <p className="text-[13px] mt-1 text-wedsy-ink-2">{day.time}</p>
+              <p className="wedsy-italic-em text-[12px] mt-3">{day.venue}</p>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/profile/InspirationCard.js
+++ b/components/profile/InspirationCard.js
@@ -1,0 +1,55 @@
+export default function InspirationCard({
+  imageSrc,
+  tagline,
+  headline,
+  ctaLabel = "Explore",
+  onTap,
+}) {
+  const cardStyle = imageSrc
+    ? {
+        backgroundImage: `url(${imageSrc})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }
+    : undefined;
+
+  return (
+    <section className="pt-2 pb-8 px-6">
+      <p className="wedsy-eyebrow">INSPIRATION</p>
+      <h2 className="wedsy-title text-[20px] mt-2 text-wedsy-ink">From the Wedsy archives</h2>
+
+      <button
+        type="button"
+        onClick={onTap}
+        style={cardStyle}
+        className={`relative w-full aspect-[4/3] mt-5 border border-wedsy-rose-100 overflow-hidden text-left ${
+          imageSrc ? "" : "bg-wedsy-rose-100"
+        }`}
+      >
+        <span
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{
+            background:
+              "linear-gradient(to top, rgba(31,26,23,0.65), rgba(31,26,23,0))",
+          }}
+        />
+        <span className="absolute inset-0 p-6 flex flex-col justify-end">
+          {tagline && (
+            <span className="font-serif italic text-[12px] tracking-[1px] uppercase text-wedsy-rose-100">
+              {tagline}
+            </span>
+          )}
+          {headline && (
+            <span className="wedsy-title text-white text-[24px] mt-1 leading-tight">
+              {headline}
+            </span>
+          )}
+          <span className="text-[12px] tracking-[2px] uppercase font-medium text-white mt-3 self-end">
+            {ctaLabel} →
+          </span>
+        </span>
+      </button>
+    </section>
+  );
+}

--- a/components/profile/ProfileHero.js
+++ b/components/profile/ProfileHero.js
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+
+export default function ProfileHero({
+  coupleName,
+  weddingDate,
+  eventDayCount = 1,
+  eventDayNames = [],
+}) {
+  const { formattedDate, countdownText } = useMemo(() => {
+    const ordinalSuffix = (day) => {
+      if (day >= 11 && day <= 13) return "th";
+      const last = day % 10;
+      if (last === 1) return "st";
+      if (last === 2) return "nd";
+      if (last === 3) return "rd";
+      return "th";
+    };
+
+    const wedding = new Date(weddingDate);
+    const today = new Date();
+    const diff = Math.ceil((wedding - today) / 86400000);
+
+    let text;
+    if (diff > 0) {
+      text = `${diff} ${diff === 1 ? "day" : "days"} to your wedding`;
+    } else if (diff === 0) {
+      text = "Today is your wedding day";
+    } else {
+      const past = Math.abs(diff);
+      text = `${past} ${past === 1 ? "day" : "days"} since your wedding`;
+    }
+
+    const day = wedding.getDate();
+    const month = wedding.toLocaleString("en-GB", { month: "long" });
+    const year = wedding.getFullYear();
+
+    return {
+      formattedDate: `${day}${ordinalSuffix(day)} ${month} ${year}`,
+      countdownText: text,
+    };
+  }, [weddingDate]);
+
+  return (
+    <section className="text-center pt-12 pb-8 px-6">
+      <p className="wedsy-eyebrow">A WEDSY WEDDING</p>
+      <h1 className="wedsy-title text-[44px] leading-[1.05] mt-3 text-wedsy-ink">
+        {coupleName}
+      </h1>
+      <p className="wedsy-italic-em text-[18px] mt-2">{formattedDate}</p>
+      <div className="wedsy-ornament-divider my-6 mx-auto"></div>
+      <p className="text-[13px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium">
+        {countdownText}
+      </p>
+      {eventDayNames.length > 0 && (
+        <p className="wedsy-subtitle mt-4 text-[12px]">
+          {eventDayNames.join(" · ")} · {eventDayCount}{" "}
+          {eventDayCount === 1 ? "event" : "events"}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/components/profile/StatsGrid.js
+++ b/components/profile/StatsGrid.js
@@ -1,0 +1,26 @@
+export default function StatsGrid({ stats = [] }) {
+  if (stats.length === 0) return null;
+
+  return (
+    <section className="pt-2 pb-8 px-6">
+      <p className="wedsy-eyebrow">AT A GLANCE</p>
+      <h2 className="wedsy-title text-[24px] mt-2 text-wedsy-ink">How things stand</h2>
+
+      <div className="grid grid-cols-2 gap-3 mt-5">
+        {stats.map((s, i) => (
+          <div key={i} className="bg-wedsy-ivory-2 border border-wedsy-rose-100 p-4">
+            <p className="text-[10px] tracking-[1px] uppercase font-medium text-wedsy-rose-600">
+              {s.label}
+            </p>
+            <p className="wedsy-title text-[32px] text-wedsy-burgundy mt-1 leading-none">
+              {s.value}
+            </p>
+            {s.sublabel && (
+              <p className="wedsy-italic-em text-[11px] mt-2 text-wedsy-ink-3">{s.sublabel}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/profile/TimelineCard.js
+++ b/components/profile/TimelineCard.js
@@ -1,0 +1,90 @@
+function formatRelativeDate(isoDate) {
+  const due = new Date(isoDate);
+  const today = new Date();
+  const stripTime = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diff = Math.round((stripTime(due) - stripTime(today)) / 86400000);
+
+  if (diff < 0) {
+    const past = Math.abs(diff);
+    return `${past} day${past === 1 ? "" : "s"} overdue`;
+  }
+  if (diff === 0) return "today";
+  if (diff === 1) return "tomorrow";
+  if (diff === 14) return "in 2 weeks";
+  if (diff <= 14) return `in ${diff} days`;
+  const day = due.getDate();
+  const month = due.toLocaleString("en-GB", { month: "short" });
+  return `${day} ${month}`;
+}
+
+const sourceColor = (source) => {
+  if (source === "AI") return "text-wedsy-rose-600";
+  if (source === "Custom") return "text-wedsy-green";
+  return "text-wedsy-ink-3";
+};
+
+export default function TimelineCard({
+  milestones = [],
+  onRegenerate,
+  onViewAll,
+  regenerating = false,
+}) {
+  const next = [...milestones]
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))
+    .slice(0, 3);
+
+  return (
+    <section className="pt-2 pb-8 px-6">
+      <div className="flex items-center justify-between">
+        <p className="wedsy-eyebrow">PLANNING TIMELINE</p>
+        <button
+          type="button"
+          onClick={onViewAll}
+          className="text-[10px] tracking-[1px] uppercase font-medium text-wedsy-rose-600"
+        >
+          View all
+        </button>
+      </div>
+      <h2 className="wedsy-title text-[24px] mt-2 text-wedsy-ink">Your road to the wedding</h2>
+      <p className="wedsy-italic-em text-[14px] mt-1">What&apos;s next, in date order</p>
+
+      <div className="mt-4 bg-wedsy-ivory-2 border border-wedsy-rose-100 p-5">
+        {next.length === 0 ? (
+          <p className="wedsy-italic-em text-[13px] text-center text-wedsy-ink-3">
+            No milestones yet. Tap Regenerate to get started.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {next.map((m) => (
+              <li key={m._id} className="flex items-center gap-3">
+                {m.status === "COMPLETED" ? (
+                  <span className="h-3 w-3 rounded-full border border-wedsy-ink-3 flex items-center justify-center text-wedsy-ink-3 text-[8px] leading-none shrink-0">
+                    ✓
+                  </span>
+                ) : (
+                  <span className="h-3 w-3 rounded-full bg-wedsy-rose-600 shrink-0" />
+                )}
+                <span className="flex-1 text-[15px] text-wedsy-ink line-clamp-1">{m.title}</span>
+                <span className={`text-[9px] tracking-[1px] uppercase font-medium shrink-0 ${sourceColor(m.source)}`}>
+                  {m.source.toUpperCase()}
+                </span>
+                <span className="text-[11px] tracking-[1px] uppercase font-medium text-wedsy-ink-3 shrink-0">
+                  {m.status === "COMPLETED" ? "DONE" : formatRelativeDate(m.dueDate)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onRegenerate}
+        disabled={regenerating}
+        className="mt-4 text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 disabled:text-wedsy-ink-3 disabled:cursor-not-allowed"
+      >
+        ↻ {regenerating ? "Regenerating…" : "Regenerate"}
+      </button>
+    </section>
+  );
+}

--- a/components/profile/TimelineCard.js
+++ b/components/profile/TimelineCard.js
@@ -83,7 +83,8 @@ export default function TimelineCard({
         disabled={regenerating}
         className="mt-4 text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 disabled:text-wedsy-ink-3 disabled:cursor-not-allowed"
       >
-        ↻ {regenerating ? "Regenerating…" : "Regenerate"}
+        <span className={`inline-block ${regenerating ? "animate-spin" : ""}`}>↻</span>{" "}
+        {regenerating ? "Regenerating…" : "Regenerate"}
       </button>
     </section>
   );

--- a/hooks/useProfileData.js
+++ b/hooks/useProfileData.js
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchTimeline } from "@/utils/api/wedding-timeline";
+
+export default function useProfileData({ eventId, token }) {
+  const [milestones, setMilestones] = useState([]);
+  const [milestonesLoading, setMilestonesLoading] = useState(true);
+  const [milestonesError, setMilestonesError] = useState(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const loadMilestones = useCallback(async () => {
+    if (!eventId || !token) {
+      if (isMountedRef.current) setMilestonesLoading(false);
+      return;
+    }
+    if (isMountedRef.current) {
+      setMilestonesLoading(true);
+      setMilestonesError(null);
+    }
+    const { data, error } = await fetchTimeline(eventId, token);
+    if (!isMountedRef.current) return;
+    if (error) {
+      setMilestonesError(error);
+      setMilestones([]);
+    } else {
+      setMilestones(data?.timeline || []);
+    }
+    setMilestonesLoading(false);
+  }, [eventId, token]);
+
+  useEffect(() => {
+    loadMilestones();
+  }, [loadMilestones]);
+
+  return {
+    milestones,
+    milestonesLoading,
+    milestonesError,
+    refetchMilestones: loadMilestones,
+  };
+}

--- a/hooks/useProfileData.js
+++ b/hooks/useProfileData.js
@@ -1,9 +1,22 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchTimeline } from "@/utils/api/wedding-timeline";
+import { fetchEvents, fetchTimeline } from "@/utils/api/wedding-timeline";
 
-export default function useProfileData({ eventId, token }) {
+function pickPrimaryEvent(events) {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const sorted = [...events].sort((a, b) => {
+    const ad = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bd = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bd - ad;
+  });
+  return sorted[0];
+}
+
+export default function useProfileData({ token }) {
+  const [event, setEvent] = useState(null);
+  const [eventLoading, setEventLoading] = useState(true);
+  const [eventError, setEventError] = useState(null);
   const [milestones, setMilestones] = useState([]);
-  const [milestonesLoading, setMilestonesLoading] = useState(true);
+  const [milestonesLoading, setMilestonesLoading] = useState(false);
   const [milestonesError, setMilestonesError] = useState(null);
   const isMountedRef = useRef(true);
 
@@ -14,34 +27,67 @@ export default function useProfileData({ eventId, token }) {
     };
   }, []);
 
-  const loadMilestones = useCallback(async () => {
-    if (!eventId || !token) {
-      if (isMountedRef.current) setMilestonesLoading(false);
-      return;
-    }
-    if (isMountedRef.current) {
-      setMilestonesLoading(true);
-      setMilestonesError(null);
-    }
-    const { data, error } = await fetchTimeline(eventId, token);
-    if (!isMountedRef.current) return;
-    if (error) {
-      setMilestonesError(error);
-      setMilestones([]);
-    } else {
-      setMilestones(data?.timeline || []);
-    }
-    setMilestonesLoading(false);
-  }, [eventId, token]);
+  const loadMilestones = useCallback(
+    async (eventId) => {
+      if (!eventId || !token) return;
+      if (isMountedRef.current) {
+        setMilestonesLoading(true);
+        setMilestonesError(null);
+      }
+      const { data, error } = await fetchTimeline(eventId, token);
+      if (!isMountedRef.current) return;
+      if (error) {
+        setMilestonesError(error);
+        setMilestones([]);
+      } else {
+        setMilestones(data?.timeline || []);
+      }
+      setMilestonesLoading(false);
+    },
+    [token]
+  );
 
   useEffect(() => {
-    loadMilestones();
-  }, [loadMilestones]);
+    const loadAll = async () => {
+      if (!token) {
+        // Idle until a real token arrives. Initial eventLoading=true holds.
+        return;
+      }
+      if (isMountedRef.current) {
+        setEventLoading(true);
+        setEventError(null);
+      }
+      const { data: events, error } = await fetchEvents(token);
+      if (!isMountedRef.current) return;
+      if (error) {
+        setEventError(error);
+        setEvent(null);
+        setEventLoading(false);
+        return;
+      }
+      const primary = pickPrimaryEvent(events);
+      setEvent(primary);
+      setEventLoading(false);
+      if (primary?._id) {
+        loadMilestones(primary._id);
+      } else {
+        setMilestones([]);
+      }
+    };
+    loadAll();
+  }, [token, loadMilestones]);
+
+  const refetchMilestones = useCallback(() => {
+    if (event?._id) loadMilestones(event._id);
+  }, [event, loadMilestones]);
 
   return {
+    event,
+    eventLoading,
+    eventError,
     milestones,
     milestonesLoading,
     milestonesError,
-    refetchMilestones: loadMilestones,
+    refetchMilestones,
   };
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import { EventPageSkeleton } from "@/components/skeletons/event";
 import { BiddingPageSkeleton, MakeupAndBeautyPageSkeleton, MakeupArtistsPageSkeleton, WedsyPackagesPageSkeleton } from "@/components/skeletons/makeup-store";
 import { DecorPageSkeleton } from "@/components/skeletons/wedding-store";
 import "@/styles/globals.css";
+import "@/styles/wedsy-design-system.css";
 import { trimTitle, trimDescription, OG_IMAGES } from "@/utils/seo";
 import { Spinner } from "flowbite-react";
 import Head from "next/head";

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -24,7 +24,7 @@ function App({ Component, pageProps }) {
   const [openLoginModalv2, setOpenLoginModalv2] = useState(false);
   const [loginSource, setLoginSource] = useState("");
   const restrictedPaths = [
-    "/wishlist", "/my-account", "/event", "/payments", "/my-orders", "/my-bids", "/chat",
+    "/wishlist", "/my-account", "/event", "/payments", "/my-orders", "/my-bids", "/chat", "/profile",
     "/makeup-and-beauty/wedsy-packages/checkout",
   ];
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,6 +6,7 @@ export default function Document() {
       <Head>
       <link href="https://fonts.googleapis.com/css2?family=Lovers+Quarrel&display=swap" rel="stylesheet"/>
       <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet"/>
+      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"/>
       </Head>
       <body>
         <Main />

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,54 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    CheckLogin();
+  }, []);
+
+  if (!user?.name) {
+    return (
+      <div className="wedsy-screen-container">
+        <p
+          className="wedsy-subtitle"
+          style={{ padding: "60px 24px", textAlign: "center" }}
+        >
+          Loading…
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Profile · Wedsy</title>
+      </Head>
+      <div className="wedsy-screen-container">
+        <div style={{ padding: "60px 24px", textAlign: "center" }}>
+          <p className="wedsy-eyebrow">WELCOME</p>
+          <h1
+            className="wedsy-title"
+            style={{ fontSize: "32px", marginTop: "12px" }}
+          >
+            Hello, {user.name || "friend"}
+          </h1>
+          <p className="wedsy-italic-em" style={{ marginTop: "8px" }}>
+            Your wedding journey, in one place
+          </p>
+          <div
+            className="wedsy-ornament-divider"
+            style={{ margin: "24px auto" }}
+          ></div>
+          <p className="wedsy-subtitle" style={{ marginTop: "16px" }}>
+            We&apos;re rebuilding your dashboard. Check back soon for the full
+            experience.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,10 +1,13 @@
+import EmptyStateStep1 from "@/components/profile/EmptyStateStep1";
+import EmptyStateStep2 from "@/components/profile/EmptyStateStep2";
 import ProfileHero from "@/components/profile/ProfileHero";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
   const router = useRouter();
+  const [step1Data, setStep1Data] = useState({ eventName: "", community: "" });
 
   useEffect(() => {
     CheckLogin();
@@ -23,18 +26,39 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     );
   }
 
+  const previewState = router.query.state;
+
   return (
     <>
       <Head>
         <title>Profile · Wedsy</title>
       </Head>
       <div className="wedsy-screen-container">
-        <ProfileHero
-          coupleName="Rohaan & Asiya"
-          weddingDate="2026-05-21"
-          eventDayCount={3}
-          eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
-        />
+        {previewState === "empty1" ? (
+          <EmptyStateStep1
+            onContinue={(data) => {
+              setStep1Data(data);
+              router.push("/profile?state=empty2");
+            }}
+          />
+        ) : previewState === "empty2" ? (
+          <EmptyStateStep2
+            eventName={step1Data.eventName || "Your wedding"}
+            community={step1Data.community || "Hindu"}
+            onBack={() => router.push("/profile?state=empty1")}
+            onComplete={(data) => {
+              console.log("Mock create event:", data);
+              router.push("/profile");
+            }}
+          />
+        ) : (
+          <ProfileHero
+            coupleName="Rohaan & Asiya"
+            weddingDate="2026-05-21"
+            eventDayCount={3}
+            eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
+          />
+        )}
       </div>
     </>
   );

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,3 +1,4 @@
+import ProfileHero from "@/components/profile/ProfileHero";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
@@ -28,26 +29,12 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
         <title>Profile · Wedsy</title>
       </Head>
       <div className="wedsy-screen-container">
-        <div style={{ padding: "60px 24px", textAlign: "center" }}>
-          <p className="wedsy-eyebrow">WELCOME</p>
-          <h1
-            className="wedsy-title"
-            style={{ fontSize: "32px", marginTop: "12px" }}
-          >
-            Hello, {user.name || "friend"}
-          </h1>
-          <p className="wedsy-italic-em" style={{ marginTop: "8px" }}>
-            Your wedding journey, in one place
-          </p>
-          <div
-            className="wedsy-ornament-divider"
-            style={{ margin: "24px auto" }}
-          ></div>
-          <p className="wedsy-subtitle" style={{ marginTop: "16px" }}>
-            We&apos;re rebuilding your dashboard. Check back soon for the full
-            experience.
-          </p>
-        </div>
+        <ProfileHero
+          coupleName="Rohaan & Asiya"
+          weddingDate="2026-05-21"
+          eventDayCount={3}
+          eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
+        />
       </div>
     </>
   );

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,6 +1,8 @@
+import AccountList from "@/components/profile/AccountList";
 import EmptyStateStep1 from "@/components/profile/EmptyStateStep1";
 import EmptyStateStep2 from "@/components/profile/EmptyStateStep2";
 import EventDaysCarousel from "@/components/profile/EventDaysCarousel";
+import InspirationCard from "@/components/profile/InspirationCard";
 import ProfileHero from "@/components/profile/ProfileHero";
 import StatsGrid from "@/components/profile/StatsGrid";
 import TimelineCard from "@/components/profile/TimelineCard";
@@ -26,6 +28,21 @@ const MOCK_STATS = [
   { label: "Vendors booked", value: 5, sublabel: "of 7 expected" },
   { label: "Paid", value: "₹4.2L", sublabel: "of ₹6.8L total" },
   { label: "Open milestones", value: 3 },
+];
+
+const MOCK_INSPIRATION = {
+  imageSrc: "https://images.unsplash.com/photo-1519741497674-611481863552?w=1200&q=80",
+  tagline: "CURATED FOR YOU",
+  headline: "Stories of weddings like yours",
+  ctaLabel: "Explore",
+};
+
+const MOCK_ACCOUNT_ITEMS = [
+  { label: "Orders", href: "/my-orders", iconName: "Package" },
+  { label: "Payments", href: "/my-payments", iconName: "CreditCard" },
+  { label: "My Bids", href: "/my-bids", iconName: "Hammer", badge: "3 new" },
+  { label: "Wishlist", href: "/wishlist", iconName: "Heart" },
+  { label: "Support", href: "#", iconName: "MessageCircle", onTap: () => console.log("Mock support") },
 ];
 
 export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
@@ -89,6 +106,17 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             />
             <EventDaysCarousel eventDays={MOCK_EVENT_DAYS} />
             <StatsGrid stats={MOCK_STATS} />
+            <InspirationCard
+              imageSrc={MOCK_INSPIRATION.imageSrc}
+              tagline={MOCK_INSPIRATION.tagline}
+              headline={MOCK_INSPIRATION.headline}
+              ctaLabel={MOCK_INSPIRATION.ctaLabel}
+              onTap={() => console.log("Mock inspiration tap")}
+            />
+            <AccountList
+              items={MOCK_ACCOUNT_ITEMS}
+              onSignOut={() => console.log("Mock sign out")}
+            />
           </>
         )}
       </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,9 +1,32 @@
 import EmptyStateStep1 from "@/components/profile/EmptyStateStep1";
 import EmptyStateStep2 from "@/components/profile/EmptyStateStep2";
+import EventDaysCarousel from "@/components/profile/EventDaysCarousel";
 import ProfileHero from "@/components/profile/ProfileHero";
+import StatsGrid from "@/components/profile/StatsGrid";
+import TimelineCard from "@/components/profile/TimelineCard";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+
+const MOCK_MILESTONES = [
+  { _id: "m1", title: "Final venue walkthrough", dueDate: "2026-05-14", status: "PENDING", source: "Custom" },
+  { _id: "m2", title: "Confirm guest count", dueDate: "2026-05-15", status: "PENDING", source: "AI" },
+  { _id: "m3", title: "Pickup outfits", dueDate: "2026-05-18", status: "PENDING", source: "Custom" },
+  { _id: "m4", title: "Book photographer", dueDate: "2026-04-10", status: "COMPLETED", source: "AI" },
+];
+
+const MOCK_EVENT_DAYS = [
+  { name: "Mehendi", date: "2026-05-19", time: "4:00 PM", venue: "Bangalore International Centre" },
+  { name: "Sangeet", date: "2026-05-20", time: "7:00 PM", venue: "Bangalore International Centre" },
+  { name: "Wedding", date: "2026-05-21", time: "11:00 AM", venue: "Bangalore International Centre" },
+];
+
+const MOCK_STATS = [
+  { label: "Days to wedding", value: 11 },
+  { label: "Vendors booked", value: 5, sublabel: "of 7 expected" },
+  { label: "Paid", value: "₹4.2L", sublabel: "of ₹6.8L total" },
+  { label: "Open milestones", value: 3 },
+];
 
 export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
   const router = useRouter();
@@ -52,12 +75,21 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             }}
           />
         ) : (
-          <ProfileHero
-            coupleName="Rohaan & Asiya"
-            weddingDate="2026-05-21"
-            eventDayCount={3}
-            eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
-          />
+          <>
+            <ProfileHero
+              coupleName="Rohaan & Asiya"
+              weddingDate="2026-05-21"
+              eventDayCount={3}
+              eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
+            />
+            <TimelineCard
+              milestones={MOCK_MILESTONES}
+              onRegenerate={() => console.log("Mock regenerate")}
+              onViewAll={() => console.log("Mock view all")}
+            />
+            <EventDaysCarousel eventDays={MOCK_EVENT_DAYS} />
+            <StatsGrid stats={MOCK_STATS} />
+          </>
         )}
       </div>
     </>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -6,16 +6,10 @@ import InspirationCard from "@/components/profile/InspirationCard";
 import ProfileHero from "@/components/profile/ProfileHero";
 import StatsGrid from "@/components/profile/StatsGrid";
 import TimelineCard from "@/components/profile/TimelineCard";
+import useProfileData from "@/hooks/useProfileData";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-
-const MOCK_MILESTONES = [
-  { _id: "m1", title: "Final venue walkthrough", dueDate: "2026-05-14", status: "PENDING", source: "Custom" },
-  { _id: "m2", title: "Confirm guest count", dueDate: "2026-05-15", status: "PENDING", source: "AI" },
-  { _id: "m3", title: "Pickup outfits", dueDate: "2026-05-18", status: "PENDING", source: "Custom" },
-  { _id: "m4", title: "Book photographer", dueDate: "2026-04-10", status: "COMPLETED", source: "AI" },
-];
 
 const MOCK_EVENT_DAYS = [
   { name: "Mehendi", date: "2026-05-19", time: "4:00 PM", venue: "Bangalore International Centre" },
@@ -48,10 +42,23 @@ const MOCK_ACCOUNT_ITEMS = [
 export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
   const router = useRouter();
   const [step1Data, setStep1Data] = useState({ eventName: "", community: "" });
+  const [token, setToken] = useState(null);
 
   useEffect(() => {
     CheckLogin();
   }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setToken(localStorage.getItem("token"));
+    }
+  }, []);
+
+  const eventIdFromUrl = router.query.eventId || null;
+  const { milestones, milestonesLoading, milestonesError } = useProfileData({
+    eventId: eventIdFromUrl,
+    token,
+  });
 
   if (!user?.name) {
     return (
@@ -100,10 +107,20 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
               eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
             />
             <TimelineCard
-              milestones={MOCK_MILESTONES}
-              onRegenerate={() => console.log("Mock regenerate")}
+              milestones={milestones}
+              onRegenerate={() => console.log("Mock regenerate (wired in 1.4.B)")}
               onViewAll={() => console.log("Mock view all")}
             />
+            {milestonesLoading && (
+              <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">
+                Loading timeline…
+              </p>
+            )}
+            {milestonesError && (
+              <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">
+                Unable to load timeline. Please reload.
+              </p>
+            )}
             <EventDaysCarousel eventDays={MOCK_EVENT_DAYS} />
             <StatsGrid stats={MOCK_STATS} />
             <InspirationCard

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -8,14 +8,7 @@ import StatsGrid from "@/components/profile/StatsGrid";
 import TimelineCard from "@/components/profile/TimelineCard";
 import useProfileData from "@/hooks/useProfileData";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-
-const MOCK_EVENT_DAYS = [
-  { name: "Mehendi", date: "2026-05-19", time: "4:00 PM", venue: "Bangalore International Centre" },
-  { name: "Sangeet", date: "2026-05-20", time: "7:00 PM", venue: "Bangalore International Centre" },
-  { name: "Wedding", date: "2026-05-21", time: "11:00 AM", venue: "Bangalore International Centre" },
-];
 
 const MOCK_STATS = [
   { label: "Days to wedding", value: 11 },
@@ -39,10 +32,31 @@ const MOCK_ACCOUNT_ITEMS = [
   { label: "Support", href: "#", iconName: "MessageCircle", onTap: () => console.log("Mock support") },
 ];
 
+function deriveCoupleName(event) {
+  return event?.name || "Your wedding";
+}
+
+function deriveWeddingDate(event) {
+  if (!event?.eventDays?.length) return null;
+  const dates = event.eventDays.map((d) => d.date).filter(Boolean).sort();
+  return dates[dates.length - 1] || null;
+}
+
+function deriveEventDayNames(event) {
+  return event?.eventDays?.map((d) => d.name).filter(Boolean) || [];
+}
+
+function shouldShowEmpty1(event, eventLoading) {
+  return !eventLoading && !event;
+}
+
+function shouldShowEmpty2(event, eventLoading) {
+  return !eventLoading && !!event && (!event.eventDays || event.eventDays.length === 0);
+}
+
 export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
-  const router = useRouter();
-  const [step1Data, setStep1Data] = useState({ eventName: "", community: "" });
   const [token, setToken] = useState(null);
+  const [regenerating, setRegenerating] = useState(false);
 
   useEffect(() => {
     CheckLogin();
@@ -54,26 +68,32 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     }
   }, []);
 
-  const eventIdFromUrl = router.query.eventId || null;
-  const { milestones, milestonesLoading, milestonesError } = useProfileData({
-    eventId: eventIdFromUrl,
-    token,
-  });
+  const {
+    event,
+    eventLoading,
+    eventError,
+    milestones,
+    milestonesLoading,
+    milestonesError,
+    refetchMilestones,
+  } = useProfileData({ token });
 
   if (!user?.name) {
     return (
       <div className="wedsy-screen-container">
-        <p
-          className="wedsy-subtitle"
-          style={{ padding: "60px 24px", textAlign: "center" }}
-        >
-          Loading…
-        </p>
+        <p className="wedsy-subtitle" style={{ padding: "60px 24px", textAlign: "center" }}>Loading…</p>
       </div>
     );
   }
 
-  const previewState = router.query.state;
+  const handleRegenerate = () => {
+    setRegenerating(true);
+    setTimeout(() => {
+      refetchMilestones();
+      setRegenerating(false);
+      console.log("Mock regenerate complete (real Anthropic call deferred to 1.4.C)");
+    }, 1500);
+  };
 
   return (
     <>
@@ -81,47 +101,38 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
         <title>Profile · Wedsy</title>
       </Head>
       <div className="wedsy-screen-container">
-        {previewState === "empty1" ? (
+        {eventLoading ? (
+          <p className="wedsy-subtitle" style={{ padding: "60px 24px", textAlign: "center" }}>Loading…</p>
+        ) : eventError ? (
+          <p className="font-serif italic text-[13px] text-wedsy-ink-3 text-center" style={{ padding: "60px 24px" }}>Unable to load your wedding. Please reload.</p>
+        ) : shouldShowEmpty1(event, eventLoading) ? (
           <EmptyStateStep1
-            onContinue={(data) => {
-              setStep1Data(data);
-              router.push("/profile?state=empty2");
-            }}
+            onContinue={(data) => console.log("Mock create event step 1:", data)}
           />
-        ) : previewState === "empty2" ? (
+        ) : shouldShowEmpty2(event, eventLoading) ? (
           <EmptyStateStep2
-            eventName={step1Data.eventName || "Your wedding"}
-            community={step1Data.community || "Hindu"}
-            onBack={() => router.push("/profile?state=empty1")}
-            onComplete={(data) => {
-              console.log("Mock create event:", data);
-              router.push("/profile");
-            }}
+            eventName={event.name || "Your wedding"}
+            community={event.community || "Hindu"}
+            onBack={() => console.log("Mock back from step 2")}
+            onComplete={(data) => console.log("Mock complete event days:", data)}
           />
         ) : (
           <>
             <ProfileHero
-              coupleName="Rohaan & Asiya"
-              weddingDate="2026-05-21"
-              eventDayCount={3}
-              eventDayNames={["Mehendi", "Sangeet", "Wedding"]}
+              coupleName={deriveCoupleName(event)}
+              weddingDate={deriveWeddingDate(event)}
+              eventDayCount={event.eventDays?.length || 0}
+              eventDayNames={deriveEventDayNames(event)}
             />
             <TimelineCard
               milestones={milestones}
-              onRegenerate={() => console.log("Mock regenerate (wired in 1.4.B)")}
+              onRegenerate={handleRegenerate}
               onViewAll={() => console.log("Mock view all")}
+              regenerating={regenerating}
             />
-            {milestonesLoading && (
-              <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">
-                Loading timeline…
-              </p>
-            )}
-            {milestonesError && (
-              <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">
-                Unable to load timeline. Please reload.
-              </p>
-            )}
-            <EventDaysCarousel eventDays={MOCK_EVENT_DAYS} />
+            {milestonesLoading && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Loading timeline…</p>}
+            {milestonesError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Unable to load timeline. Please reload.</p>}
+            <EventDaysCarousel eventDays={event.eventDays || []} />
             <StatsGrid stats={MOCK_STATS} />
             <InspirationCard
               imageSrc={MOCK_INSPIRATION.imageSrc}

--- a/styles/wedsy-design-system.css
+++ b/styles/wedsy-design-system.css
@@ -1,0 +1,55 @@
+/*
+ * Design system for the new Profile-tab redesign.
+ * Scoped via .wedsy-screen-container — does not affect existing pages.
+ */
+
+.wedsy-screen-container {
+  max-width: 480px;
+  margin: 0 auto;
+  min-height: 100vh;
+  background: #FBF7F2;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+}
+
+.wedsy-screen-bg {
+  background: #F5EFE6;
+}
+
+.wedsy-eyebrow {
+  letter-spacing: 2px;
+  font-size: 10px;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: #9C4A38;
+}
+
+.wedsy-title {
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-weight: 400;
+}
+
+.wedsy-italic-em {
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-style: italic;
+  font-weight: 300;
+  color: #9C4A38;
+}
+
+.wedsy-subtitle {
+  font-family: "Cormorant Garamond", Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
+  color: #8B7E72;
+}
+
+.wedsy-ornament-divider {
+  display: block;
+  width: 30px;
+  height: 0.5px;
+  margin: 0 auto;
+  background-color: #5B1F1A;
+  opacity: 0.3;
+  border: 0;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,6 +55,36 @@ module.exports = {
           "50%": { transform: "scale(1)" },
         },
       },
+      colors: {
+        wedsy: {
+          ivory: "#FBF7F2",
+          "ivory-2": "#F5EFE6",
+          rose: {
+            50: "#FAEEEA",
+            100: "#F2D9D1",
+            200: "#E8B8A8",
+            400: "#C97A65",
+            600: "#9C4A38",
+          },
+          burgundy: {
+            DEFAULT: "#5B1F1A",
+            soft: "#7A2E26",
+          },
+          ink: {
+            DEFAULT: "#1F1A17",
+            2: "#4A4038",
+            3: "#8B7E72",
+          },
+          gold: "#B08A4A",
+          green: "#4A7A4F",
+          amber: "#B07A2A",
+          danger: "#9C3A3A",
+        },
+      },
+      fontFamily: {
+        serif: ['"Cormorant Garamond"', "Georgia", "serif"],
+        sans: ["Inter", "Montserrat", "system-ui", "sans-serif"],
+      },
     },
   },
   plugins: [require("flowbite/plugin")],

--- a/utils/api/wedding-timeline.js
+++ b/utils/api/wedding-timeline.js
@@ -1,0 +1,70 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL;
+
+if (!API_BASE && typeof window !== "undefined") {
+  console.error(
+    "[wedding-timeline] NEXT_PUBLIC_API_URL is not set — API calls will fail."
+  );
+}
+
+const STATUS_TO_CODE = {
+  400: "BAD_REQUEST",
+  401: "UNAUTHORIZED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  503: "SERVICE_UNAVAILABLE",
+};
+
+async function authedRequest(method, path, token, body) {
+  const headers = { Authorization: `Bearer ${token}` };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+
+  try {
+    const response = await fetch(`${API_BASE}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    let parsed = null;
+    try {
+      parsed = await response.json();
+    } catch {
+      parsed = {};
+    }
+
+    if (response.ok) {
+      return { data: parsed, error: null };
+    }
+
+    const code = STATUS_TO_CODE[response.status] || "SERVER_ERROR";
+    const message =
+      (parsed && parsed.error) ||
+      `Request failed with status ${response.status}`;
+    return { data: null, error: { code, message } };
+  } catch (err) {
+    return {
+      data: null,
+      error: {
+        code: "NETWORK_ERROR",
+        message: err.message || "Network failure",
+      },
+    };
+  }
+}
+
+export async function fetchTimeline(eventId, token) {
+  return authedRequest("GET", `/event/${eventId}/wedding-timeline`, token);
+}
+
+export async function regenerateTimeline(eventId, token) {
+  return authedRequest(
+    "POST",
+    `/event/${eventId}/wedding-timeline/regenerate`,
+    token,
+    {}
+  );
+}
+
+export async function fetchEvents(token) {
+  return authedRequest("GET", `/event`, token);
+}


### PR DESCRIPTION
Deploys Phase 1 of the Wedsy User App refresh to production.

Merges PR #15 (https://github.com/WedsyOrg/wedsy-user/pull/15) from staging to main. CloudFront will pick up the change automatically and propagate to wedsy.in.

## What's shipping

New editorial-magazine Profile dashboard at /profile, replacing the legacy layout. Includes:
- Hero with real-time wedding countdown
- AI Timeline card (top 3 milestones, real backend data)
- Event days horizontal carousel (real data)
- Stats grid (mocked — no endpoint yet)
- Inspiration card (mocked — no source yet)
- Account list (real legacy page links)
- Empty states Step 1 + Step 2 for users without an event

8 commits, +968 / -1 lines. /profile route bundle 7.73 kB / 171 kB First Load.

## What's deferred

- Real Anthropic POST for Regenerate button (currently uses setTimeout mock; flow is visually complete)
- Stats grid + Inspiration card real data
- Desktop-specific layout (Phase 1.5 follows)

Phase 1 Build Log: https://www.notion.so/35972ef954ed81f79687d561bfc9bcd0