### PR TITLE
feat(profile): real Anthropic regenerate + past-event UX (1.4.C)

### DIFF
--- a/components/cards/DecorCard.js
+++ b/components/cards/DecorCard.js
@@ -27,7 +27,7 @@ export default function DecorCard({ decor = {}, size = "normal" }) {
   return (
     <Link
       href={`/decor/view/${_id}`}
-      className="group block h-full w-full flex flex-col"
+      className="group block h-full w-full flex flex-col hover:shadow-xl active:scale-95 transition-all duration-300"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/components/cards/DecorCard.js
+++ b/components/cards/DecorCard.js
@@ -1,8 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 
-// Add a 'size' prop with a default value of 'normal'
-export default function DecorCard({ decor = {}, size = "normal" }) {
+export default function DecorCard({ decor = {}, size = "normal", hideInfo = false, fillContainer = false }) {
   if (!decor || !decor._id) return null;
 
   const {
@@ -32,14 +31,14 @@ export default function DecorCard({ decor = {}, size = "normal" }) {
       rel="noopener noreferrer"
     >
       {/* IMAGE SECTION */}
-      <div className="relative w-full overflow-hidden rounded-2xl">
+      <div className={`relative w-full overflow-hidden rounded-2xl ${fillContainer ? 'h-full' : ''}`}>
         <Image
           src={thumbnail || "/placeholder.webp"}
           alt={name}
           width={0}
           height={0}
           sizes="(max-width: 768px) 50vw, 33vw"
-          style={{ objectFit: "contain", width: "100%", height: "auto" }}
+          style={{ objectFit: "contain", width: "100%", height: fillContainer ? "100%" : "auto" }}
           className="transition-transform duration-500 ease-in-out md:group-hover:scale-110"
           placeholder="blur"
           blurDataURL="/placeholder.webp"
@@ -61,15 +60,17 @@ export default function DecorCard({ decor = {}, size = "normal" }) {
         </div>
       </div>
 
-      {/* DESKTOP: Name & Price section */}
-      <div className="mt-2 w-full flex justify-between items-center gap-2 bg-white rounded-xl px-3 py-2 md:flex hidden">
-        <p className="font-semibold text-gray-800 truncate min-w-0 flex-shrink" title={name}>
-          {name}
-        </p>
-        <p className="text-sm font-medium text-rose-900 flex-shrink-0 whitespace-nowrap">
-          ₹ {displayPrice} {unitSuffix}
-        </p>
-      </div>
+      {/* DESKTOP: Name & Price section — hidden when inside carousel */}
+      {!hideInfo && (
+        <div className="mt-2 w-full flex justify-between items-center gap-2 bg-white rounded-xl px-3 py-2 md:flex hidden">
+          <p className="font-semibold text-gray-800 truncate min-w-0 flex-shrink" title={name}>
+            {name}
+          </p>
+          <p className="text-sm font-medium text-rose-900 flex-shrink-0 whitespace-nowrap">
+            ₹ {displayPrice} {unitSuffix}
+          </p>
+        </div>
+      )}
     </Link>
   );
 }

--- a/components/cards/DecorCard.js
+++ b/components/cards/DecorCard.js
@@ -24,9 +24,6 @@ export default function DecorCard({ decor = {}, size = "normal" }) {
 
   const unitSuffix = category === "Pathway" && unit ? `/ ${unit}` : "";
 
-  // Conditionally set the height class based on the 'size' prop
-  const imageHeightClass = size === "small" ? "min-h-[200px]" : "min-h-[280px]";
-
   return (
     <Link
       href={`/decor/view/${_id}`}
@@ -35,16 +32,14 @@ export default function DecorCard({ decor = {}, size = "normal" }) {
       rel="noopener noreferrer"
     >
       {/* IMAGE SECTION */}
-      {/* Apply the conditional height class here */}
-      <div
-        className={`relative w-full ${imageHeightClass} overflow-hidden rounded-2xl`}
-      >
+      <div className="relative w-full overflow-hidden rounded-2xl">
         <Image
           src={thumbnail || "/placeholder.webp"}
           alt={name}
-          fill
+          width={0}
+          height={0}
           sizes="(max-width: 768px) 50vw, 33vw"
-          style={{ objectFit: "cover" }}
+          style={{ objectFit: "contain", width: "100%", height: "auto" }}
           className="transition-transform duration-500 ease-in-out md:group-hover:scale-110"
           placeholder="blur"
           blurDataURL="/placeholder.webp"

--- a/components/chat/ChatSideBar.js
+++ b/components/chat/ChatSideBar.js
@@ -4,6 +4,7 @@ import { Avatar } from "flowbite-react";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { FaWhatsapp } from "react-icons/fa";
+import { connectSocket } from "@/lib/socket";
 
 export default function ChatSideBar({}) {
   const [chats, setChats] = useState([]);
@@ -31,6 +32,42 @@ export default function ChatSideBar({}) {
   useEffect(() => {
     fetchChats();
   }, []);
+
+  // Live updates: bump unread + lastMessage when a new message arrives.
+  useEffect(() => {
+    const socket = connectSocket();
+    if (!socket) return;
+
+    const onNewMessage = (msg) => {
+      if (!msg || !msg.chat) return;
+      setChats((prev) => {
+        const list = Array.isArray(prev) ? prev : [];
+        let found = false;
+        const updated = list.map((c) => {
+          if (c._id !== msg.chat) return c;
+          found = true;
+          // Don't bump unread for the chat the user is currently viewing.
+          const isOpen = chatId && chatId === msg.chat;
+          return {
+            ...c,
+            lastMessage: msg,
+            unreadCount: isOpen ? 0 : (c.unreadCount || 0) + 1,
+            updatedAt: msg.createdAt || new Date().toISOString(),
+          };
+        });
+        if (!found) fetchChats();
+        updated.sort((a, b) => {
+          const ta = new Date(a?.lastMessage?.createdAt || a?.updatedAt || 0).getTime();
+          const tb = new Date(b?.lastMessage?.createdAt || b?.updatedAt || 0).getTime();
+          return tb - ta;
+        });
+        return updated;
+      });
+    };
+
+    socket.on("message:new", onNewMessage);
+    return () => socket.off("message:new", onNewMessage);
+  }, [chatId]);
 
   return (
     <>
@@ -71,7 +108,7 @@ export default function ChatSideBar({}) {
                 />
               </div>
               <div className="min-w-0 flex-1 flex flex-col py-4 justify-start h-full border-b">
-                <div className="flex flex-row mb-auto gap-2">
+                <div className="flex flex-row mb-auto gap-2 items-center">
                   <p className="text-lg font-medium text-gray-900 dark:text-white grow">
                     {chat?.vendor?.name}
                   </p>
@@ -79,6 +116,11 @@ export default function ChatSideBar({}) {
                     <p className="flex-shrink-0 text-[#FF307E]">
                       {formatMessageTime(chat?.lastMessage?.createdAt)}
                     </p>
+                  )}
+                  {chat?.unreadCount > 0 && (
+                    <span className="flex-shrink-0 bg-[#FF307E] text-white text-xs rounded-full min-w-[20px] h-5 px-1.5 inline-flex items-center justify-center">
+                      {chat.unreadCount}
+                    </span>
                   )}
                 </div>
                 <p className="truncate text-sm text-gray-500 dark:text-gray-400">

--- a/components/chat/ChatWindow.js
+++ b/components/chat/ChatWindow.js
@@ -1,8 +1,9 @@
 import { toPriceString } from "@/utils/text";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VscSend } from "react-icons/vsc";
 import ChatMessage from "./ChatMessage";
+import { connectSocket, getSocket } from "@/lib/socket";
 
 export default function ChatWindow({ user }) {
   const [chat, setChat] = useState([]);
@@ -17,6 +18,9 @@ export default function ChatWindow({ user }) {
   const [blockingBidding, setBlockingBidding] = useState(null);
   const [ctaLoading, setCtaLoading] = useState(false);
   const [ctaError, setCtaError] = useState("");
+  const [isOtherTyping, setIsOtherTyping] = useState(false);
+  const typingEmitTimerRef = useRef(null);
+  const typingHideTimerRef = useRef(null);
   const router = useRouter();
   const { chatId } = router.query;
 
@@ -171,6 +175,60 @@ export default function ChatWindow({ user }) {
       fetchChatMessages();
     }
   }, [chatId]);
+
+  // Real-time WebSocket: live message receive + typing indicators.
+  useEffect(() => {
+    if (!chatId) return;
+    const socket = connectSocket();
+    if (!socket) return;
+
+    const onNewMessage = (msg) => {
+      if (!msg || msg.chat !== chatId) return;
+      setChat((prev) => {
+        const existing = prev?.messages || [];
+        if (existing.some((m) => m?._id === msg._id)) return prev;
+        const next = { ...prev, messages: [msg, ...existing] };
+        evaluatePaymentStatus(next);
+        return next;
+      });
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+      if (apiUrl) {
+        fetch(`${apiUrl}/chat/${encodeURIComponent(chatId)}/mark-read`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }).catch(() => {});
+      }
+    };
+
+    const onTypingStart = (data) => {
+      if (!data || data.chatId !== chatId) return;
+      if (typingHideTimerRef.current) clearTimeout(typingHideTimerRef.current);
+      setIsOtherTyping(true);
+      typingHideTimerRef.current = setTimeout(() => setIsOtherTyping(false), 3000);
+    };
+
+    const onTypingStop = (data) => {
+      if (!data || data.chatId !== chatId) return;
+      if (typingHideTimerRef.current) clearTimeout(typingHideTimerRef.current);
+      setIsOtherTyping(false);
+    };
+
+    socket.on("message:new", onNewMessage);
+    socket.on("typing:start", onTypingStart);
+    socket.on("typing:stop", onTypingStop);
+
+    return () => {
+      socket.off("message:new", onNewMessage);
+      socket.off("typing:start", onTypingStart);
+      socket.off("typing:stop", onTypingStop);
+      try { socket.emit("typing:stop", { chatId }); } catch (_) {}
+      if (typingEmitTimerRef.current) clearTimeout(typingEmitTimerRef.current);
+      if (typingHideTimerRef.current) clearTimeout(typingHideTimerRef.current);
+    };
+  }, [chatId, evaluatePaymentStatus]);
 
   useEffect(() => {
     if (!paymentRequired || !blockingMessageId || !chat?.messages) {
@@ -539,6 +597,9 @@ export default function ChatWindow({ user }) {
           </div>
         )}
         <div className="p-4 flex flex-col md:flex-row md:items-center gap-2 bg-white border-t border-gray-200">
+          {isOtherTyping && (
+            <div className="px-2 -mt-2 text-xs text-gray-500 italic">typing…</div>
+          )}
           <div className="w-full flex flex-row gap-2">
             <input
               id="messageInput"
@@ -550,6 +611,14 @@ export default function ChatWindow({ user }) {
                 setContent(e.target.value);
                 if (sendError) {
                   setSendError("");
+                }
+                const sock = getSocket();
+                if (sock && chatId) {
+                  sock.emit("typing:start", { chatId });
+                  if (typingEmitTimerRef.current) clearTimeout(typingEmitTimerRef.current);
+                  typingEmitTimerRef.current = setTimeout(() => {
+                    sock.emit("typing:stop", { chatId });
+                  }, 2000);
                 }
               }}
               onKeyDown={(e) => {

--- a/components/layout/LoginModal.js
+++ b/components/layout/LoginModal.js
@@ -5,7 +5,7 @@ import {
   Spinner
 } from "flowbite-react";
 import { useEffect, useState } from "react";
-import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
+import { COUNTRIES, getCountry, isIndia, isOther, isValidCustomCode, effectiveCountryCode, detectCountryCode } from "@/utils/countries";
 
 export default function LoginModal({
   openLoginModal,
@@ -17,6 +17,7 @@ export default function LoginModal({
 }) {
   const [data, setData] = useState({
     countryCode: "+91",
+    customCountryCode: "+",
     phone: "",
     loading: false,
     success: false,
@@ -37,10 +38,15 @@ export default function LoginModal({
   }, []);
 
   const country = getCountry(data.countryCode);
+  const effectiveCC = effectiveCountryCode(data.countryCode, data.customCountryCode);
 
   const SendOTP = () => {
     setData({ ...data, loading: true, message: "" });
-    if (isIndia(data.countryCode)) {
+    if (isOther(data.countryCode) && !isValidCustomCode(data.customCountryCode)) {
+      setData({ ...data, loading: false, message: "Enter a valid country code (e.g. +49)" });
+      return;
+    }
+    if (isIndia(effectiveCC)) {
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -65,7 +71,7 @@ export default function LoginModal({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phone: data.phone,
-          countryCode: data.countryCode,
+          countryCode: effectiveCC,
         }),
       })
         .then((r) => r.json())
@@ -87,7 +93,7 @@ export default function LoginModal({
 
   const handleLogin = () => {
     setData({ ...data, loading: true });
-    if (isIndia(data.countryCode)) {
+    if (isIndia(effectiveCC)) {
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -126,7 +132,7 @@ export default function LoginModal({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phone: data.phone,
-          countryCode: data.countryCode,
+          countryCode: effectiveCC,
           otp: data.Otp,
           referenceId: data.ReferenceId,
         }),
@@ -181,7 +187,7 @@ export default function LoginModal({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         phone: data.phone,
-        countryCode: data.countryCode,
+        countryCode: effectiveCC,
         name: data.name,
         email: data.email,
         signupToken: data.signupToken,
@@ -220,13 +226,15 @@ export default function LoginModal({
       });
   };
 
-  const isPhoneValid = isIndia(data.countryCode)
+  const isPhoneValid = isIndia(effectiveCC)
     ? /^\d{10}$/.test(data.phone)
     : data.phone.length >= Math.min(8, country.digits);
 
+  const customCodeOK = !isOther(data.countryCode) || isValidCustomCode(data.customCountryCode);
+
   const isDisabled = data.needsSignup
     ? !data.name || !data.email || data.loading
-    : !data.phone || !isPhoneValid || data.loading || (data.otpSent ? !data.Otp : false);
+    : !data.phone || !isPhoneValid || !customCodeOK || data.loading || (data.otpSent ? !data.Otp : false);
 
   return (
     <>
@@ -250,11 +258,11 @@ export default function LoginModal({
                       value={data.countryCode}
                       onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                       disabled={data.otpSent}
-                      className="w-28 text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                      className="w-[120px] text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
                     >
                       {COUNTRIES.map((c) => (
                         <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                          {c.flag} {c.code}
+                          {c.flag} {isOther(c.code) ? "Other" : c.code}
                         </option>
                       ))}
                     </select>
@@ -270,6 +278,21 @@ export default function LoginModal({
                       className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
                     />
                   </div>
+                  {isOther(data.countryCode) && (
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      placeholder="+49"
+                      value={data.customCountryCode}
+                      maxLength={5}
+                      onChange={(e) => {
+                        const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                        setData({ ...data, customCountryCode: "+" + digits });
+                      }}
+                      disabled={data.otpSent}
+                      className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                    />
+                  )}
                   {data.otpSent && (
                     <input
                       type="text"

--- a/components/layout/LoginModal.js
+++ b/components/layout/LoginModal.js
@@ -250,10 +250,10 @@ export default function LoginModal({
                       value={data.countryCode}
                       onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                       disabled={data.otpSent}
-                      className="text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                      className="w-28 text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
                     >
                       {COUNTRIES.map((c) => (
-                        <option key={`${c.code}-${c.name}`} value={c.code}>
+                        <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
                           {c.flag} {c.code}
                         </option>
                       ))}

--- a/components/layout/LoginModal.js
+++ b/components/layout/LoginModal.js
@@ -4,7 +4,8 @@ import {
   Modal,
   Spinner
 } from "flowbite-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
 
 export default function LoginModal({
   openLoginModal,
@@ -15,6 +16,7 @@ export default function LoginModal({
   CheckLogin,
 }) {
   const [data, setData] = useState({
+    countryCode: "+91",
     phone: "",
     loading: false,
     success: false,
@@ -22,78 +24,210 @@ export default function LoginModal({
     Otp: "",
     ReferenceId: "",
     message: "",
+    signupToken: "",
+    needsSignup: false,
+    name: "",
+    email: "",
   });
+
+  useEffect(() => {
+    detectCountryCode().then((code) => {
+      setData((d) => ({ ...d, countryCode: code }));
+    });
+  }, []);
+
+  const country = getCountry(data.countryCode);
+
   const SendOTP = () => {
-    setData({
-      ...data,
-      loading: true,
-    });
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        phone: `+91${data.phone}`,
-      }),
-    })
-      .then((response) => response.json())
-      .then((response) => {
-        setData({
-          ...data,
-          loading: false,
-          otpSent: true,
-          ReferenceId: response.ReferenceId,
-        });
+    setData({ ...data, loading: true, message: "" });
+    if (isIndia(data.countryCode)) {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone: `+91${data.phone}` }),
       })
-      .catch((error) => {
-        console.error("There was a problem with the fetch operation:", error);
-      });
+        .then((r) => r.json())
+        .then((response) => {
+          setData({
+            ...data,
+            loading: false,
+            otpSent: true,
+            ReferenceId: response.ReferenceId,
+          });
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    } else {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp/international`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: data.phone,
+          countryCode: data.countryCode,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          setData({
+            ...data,
+            loading: false,
+            otpSent: true,
+            ReferenceId: response.ReferenceId,
+            message: response.message || "OTP sent on WhatsApp",
+          });
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    }
   };
+
   const handleLogin = () => {
-    setData({
-      ...data,
-      loading: true,
-    });
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
+    setData({ ...data, loading: true });
+    if (isIndia(data.countryCode)) {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: `+91${data.phone}`,
+          Otp: data.Otp,
+          ReferenceId: data.ReferenceId,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          if (response.message === "Login Successful" && response.token) {
+            setData({
+              ...data,
+              phone: "",
+              loading: false,
+              success: true,
+              otpSent: false,
+              Otp: "",
+              ReferenceId: "",
+              message: "",
+            });
+            localStorage.setItem("token", response.token);
+            CheckLogin();
+          } else {
+            setData({ ...data, loading: false, Otp: "", message: response.message });
+          }
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    } else {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/verify/international`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: data.phone,
+          countryCode: data.countryCode,
+          otp: data.Otp,
+          referenceId: data.ReferenceId,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          if (response.userExists && response.token) {
+            localStorage.setItem("token", response.token);
+            setData({
+              ...data,
+              phone: "",
+              loading: false,
+              success: true,
+              otpSent: false,
+              Otp: "",
+              ReferenceId: "",
+              message: "",
+            });
+            CheckLogin();
+          } else if (response.userExists === false && response.signupToken) {
+            setData({
+              ...data,
+              loading: false,
+              needsSignup: true,
+              signupToken: response.signupToken,
+              message: "",
+            });
+          } else {
+            setData({
+              ...data,
+              loading: false,
+              Otp: "",
+              message: response.message || "Invalid or expired OTP",
+            });
+          }
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    }
+  };
+
+  const handleSignup = () => {
+    if (!data.name || !data.email) {
+      setData({ ...data, message: "Name and email are required" });
+      return;
+    }
+    setData({ ...data, loading: true });
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup/international`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        phone: `+91${data.phone}`,
-        Otp: data.Otp,
-        ReferenceId: data.ReferenceId,
+        phone: data.phone,
+        countryCode: data.countryCode,
+        name: data.name,
+        email: data.email,
+        signupToken: data.signupToken,
       }),
     })
-      .then((response) => response.json())
+      .then((r) => r.json())
       .then((response) => {
-        if (response.message === "Login Successful" && response.token) {
+        if (response.token) {
+          localStorage.setItem("token", response.token);
           setData({
             ...data,
             phone: "",
             loading: false,
             success: true,
             otpSent: false,
+            needsSignup: false,
             Otp: "",
             ReferenceId: "",
+            signupToken: "",
+            name: "",
+            email: "",
             message: "",
           });
-          localStorage.setItem("token", response.token);
           CheckLogin();
         } else {
           setData({
             ...data,
             loading: false,
-            Otp: "",
-            message: response.message,
+            message: response.message || "Account creation failed",
           });
         }
       })
       .catch((error) => {
         console.error("There was a problem with the fetch operation:", error);
+        setData({ ...data, loading: false });
       });
   };
+
+  const isPhoneValid = isIndia(data.countryCode)
+    ? /^\d{10}$/.test(data.phone)
+    : data.phone.length >= Math.min(8, country.digits);
+
+  const isDisabled = data.needsSignup
+    ? !data.name || !data.email || data.loading
+    : !data.phone || !isPhoneValid || data.loading || (data.otpSent ? !data.Otp : false);
+
   return (
     <>
       <Modal
@@ -106,50 +240,80 @@ export default function LoginModal({
         <Modal.Body>
           <div className="space-y-6">
             <h3 className="text-xl font-medium text-gray-900 dark:text-white text-center">
-              Login to proceed
+              {data.needsSignup ? "Create your account" : "Login to proceed"}
             </h3>
             <div className=" gap-6 flex flex-col w-2/3 mx-auto">
-              <input
-                type="text"
-                placeholder="PHONE NO."
-                value={data.phone}
-                onChange={(e) =>
-                  setData({
-                    ...data,
-                    phone: e.target.value,
-                  })
-                }
-                name="phone"
-                className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 outline-0 placeholder:text-black"
-              />
-              {data.otpSent && (
-                <input
-                  type="text"
-                  placeholder="OTP"
-                  value={data.Otp}
-                  onChange={(e) =>
-                    setData({
-                      ...data,
-                      Otp: e.target.value,
-                    })
-                  }
-                  name="otp"
-                  className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 outline-0 placeholder:text-black"
-                />
+              {!data.needsSignup && (
+                <>
+                  <div className="flex gap-2">
+                    <select
+                      value={data.countryCode}
+                      onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                      disabled={data.otpSent}
+                      className="text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                    >
+                      {COUNTRIES.map((c) => (
+                        <option key={`${c.code}-${c.name}`} value={c.code}>
+                          {c.flag} {c.code}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      type="tel"
+                      inputMode="numeric"
+                      placeholder={`${country.digits} digits`}
+                      value={data.phone}
+                      maxLength={country.digits}
+                      onChange={(e) => setData({ ...data, phone: e.target.value.replace(/\D/g, "") })}
+                      disabled={data.otpSent}
+                      name="phone"
+                      className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                    />
+                  </div>
+                  {data.otpSent && (
+                    <input
+                      type="text"
+                      placeholder="OTP"
+                      value={data.Otp}
+                      onChange={(e) => setData({ ...data, Otp: e.target.value })}
+                      name="otp"
+                      className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 outline-0 placeholder:text-black"
+                    />
+                  )}
+                </>
+              )}
+              {data.needsSignup && (
+                <>
+                  <input
+                    type="text"
+                    placeholder="Name"
+                    value={data.name}
+                    onChange={(e) => setData({ ...data, name: e.target.value })}
+                    className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                  />
+                  <input
+                    type="email"
+                    placeholder="Email"
+                    value={data.email}
+                    onChange={(e) => setData({ ...data, email: e.target.value })}
+                    className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                  />
+                </>
               )}
               {data.message && <p className="text-red-500">{data.message}</p>}
             </div>
             <button
               type="submit"
               className="rounded-full bg-black text-white py-2 block w-3/4 mx-auto disabled:bg-black/50"
-              disabled={
-                !data.phone ||
-                !/^\d{10}$/.test(data.phone) ||
-                data.loading ||
-                (data.otpSent ? !data.Otp : false)
-              }
+              disabled={isDisabled}
               onClick={() => {
-                data.otpSent ? handleLogin() : SendOTP();
+                if (data.needsSignup) {
+                  handleSignup();
+                } else if (data.otpSent) {
+                  handleLogin();
+                } else {
+                  SendOTP();
+                }
               }}
             >
               {data.loading ? (
@@ -157,6 +321,8 @@ export default function LoginModal({
                   <Spinner size="sm" />
                   <span className="pl-3">Loading...</span>
                 </>
+              ) : data.needsSignup ? (
+                <>Create account</>
               ) : (
                 <>Login</>
               )}

--- a/components/layout/LoginModal.js
+++ b/components/layout/LoginModal.js
@@ -287,7 +287,12 @@ export default function LoginModal({
                       maxLength={5}
                       onChange={(e) => {
                         const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                        setData({ ...data, customCountryCode: "+" + digits });
+                        const newCustom = "+" + digits;
+                        if (newCustom === "+91") {
+                          setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                        } else {
+                          setData({ ...data, customCountryCode: newCustom });
+                        }
                       }}
                       disabled={data.otpSent}
                       className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"

--- a/components/layout/LoginModal.js
+++ b/components/layout/LoginModal.js
@@ -254,18 +254,52 @@ export default function LoginModal({
               {!data.needsSignup && (
                 <>
                   <div className="flex gap-2">
-                    <select
-                      value={data.countryCode}
-                      onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
-                      disabled={data.otpSent}
-                      className="w-[120px] text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
-                    >
-                      {COUNTRIES.map((c) => (
-                        <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                          {c.flag} {isOther(c.code) ? "Other" : c.code}
-                        </option>
-                      ))}
-                    </select>
+                    {isOther(data.countryCode) ? (
+                      <div className="w-[120px] flex items-center border-b border-b-black">
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          placeholder="+49"
+                          value={data.customCountryCode}
+                          maxLength={5}
+                          autoFocus
+                          onChange={(e) => {
+                            const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                            const newCustom = "+" + digits;
+                            if (newCustom === "+91") {
+                              setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                            } else {
+                              setData({ ...data, customCountryCode: newCustom });
+                            }
+                          }}
+                          disabled={data.otpSent}
+                          className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 outline-0 placeholder:text-black"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setData({ ...data, countryCode: "+91", customCountryCode: "+" })}
+                          disabled={data.otpSent}
+                          title="Back to country list"
+                          aria-label="Back to country list"
+                          className="text-gray-500 hover:text-black text-lg leading-none px-1"
+                        >
+                          ×
+                        </button>
+                      </div>
+                    ) : (
+                      <select
+                        value={data.countryCode}
+                        onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                        disabled={data.otpSent}
+                        className="w-[120px] text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                      >
+                        {COUNTRIES.map((c) => (
+                          <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
+                            {c.flag} {isOther(c.code) ? "Other" : c.code}
+                          </option>
+                        ))}
+                      </select>
+                    )}
                     <input
                       type="tel"
                       inputMode="numeric"
@@ -278,26 +312,6 @@ export default function LoginModal({
                       className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
                     />
                   </div>
-                  {isOther(data.countryCode) && (
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      placeholder="+49"
-                      value={data.customCountryCode}
-                      maxLength={5}
-                      onChange={(e) => {
-                        const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                        const newCustom = "+" + digits;
-                        if (newCustom === "+91") {
-                          setData({ ...data, countryCode: "+91", customCountryCode: "+" });
-                        } else {
-                          setData({ ...data, customCountryCode: newCustom });
-                        }
-                      }}
-                      disabled={data.otpSent}
-                      className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
-                    />
-                  )}
                   {data.otpSent && (
                     <input
                       type="text"

--- a/components/layout/LoginModalv2.js
+++ b/components/layout/LoginModalv2.js
@@ -256,18 +256,52 @@ export default function LoginModalv2({
               {!data.needsSignup && (
                 <>
                   <div className="flex gap-2">
-                    <select
-                      value={data.countryCode}
-                      onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
-                      disabled={data.otpSent}
-                      className="w-[120px] text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
-                    >
-                      {COUNTRIES.map((c) => (
-                        <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                          {c.flag} {isOther(c.code) ? "Other" : c.code}
-                        </option>
-                      ))}
-                    </select>
+                    {isOther(data.countryCode) ? (
+                      <div className="w-[120px] flex items-center border-b border-b-black">
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          placeholder="+49"
+                          value={data.customCountryCode}
+                          maxLength={5}
+                          autoFocus
+                          onChange={(e) => {
+                            const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                            const newCustom = "+" + digits;
+                            if (newCustom === "+91") {
+                              setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                            } else {
+                              setData({ ...data, customCountryCode: newCustom });
+                            }
+                          }}
+                          disabled={data.otpSent}
+                          className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 outline-0 placeholder:text-black"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setData({ ...data, countryCode: "+91", customCountryCode: "+" })}
+                          disabled={data.otpSent}
+                          title="Back to country list"
+                          aria-label="Back to country list"
+                          className="text-gray-500 hover:text-black text-lg leading-none px-1"
+                        >
+                          ×
+                        </button>
+                      </div>
+                    ) : (
+                      <select
+                        value={data.countryCode}
+                        onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                        disabled={data.otpSent}
+                        className="w-[120px] text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                      >
+                        {COUNTRIES.map((c) => (
+                          <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
+                            {c.flag} {isOther(c.code) ? "Other" : c.code}
+                          </option>
+                        ))}
+                      </select>
+                    )}
                     <input
                       type="tel"
                       inputMode="numeric"
@@ -280,26 +314,7 @@ export default function LoginModalv2({
                       className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
                     />
                   </div>
-                  {isOther(data.countryCode) && (
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      placeholder="+49"
-                      value={data.customCountryCode}
-                      maxLength={5}
-                      onChange={(e) => {
-                        const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                        const newCustom = "+" + digits;
-                        if (newCustom === "+91") {
-                          setData({ ...data, countryCode: "+91", customCountryCode: "+" });
-                        } else {
-                          setData({ ...data, customCountryCode: newCustom });
-                        }
-                      }}
-                      disabled={data.otpSent}
-                      className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
-                    />
-                  )}
+
                   {data.otpSent && (
                     <input
                       type="text"

--- a/components/layout/LoginModalv2.js
+++ b/components/layout/LoginModalv2.js
@@ -289,7 +289,12 @@ export default function LoginModalv2({
                       maxLength={5}
                       onChange={(e) => {
                         const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                        setData({ ...data, customCountryCode: "+" + digits });
+                        const newCustom = "+" + digits;
+                        if (newCustom === "+91") {
+                          setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                        } else {
+                          setData({ ...data, customCountryCode: newCustom });
+                        }
                       }}
                       disabled={data.otpSent}
                       className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"

--- a/components/layout/LoginModalv2.js
+++ b/components/layout/LoginModalv2.js
@@ -252,10 +252,10 @@ export default function LoginModalv2({
                       value={data.countryCode}
                       onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                       disabled={data.otpSent}
-                      className="text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                      className="w-28 text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
                     >
                       {COUNTRIES.map((c) => (
-                        <option key={`${c.code}-${c.name}`} value={c.code}>
+                        <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
                           {c.flag} {c.code}
                         </option>
                       ))}

--- a/components/layout/LoginModalv2.js
+++ b/components/layout/LoginModalv2.js
@@ -5,7 +5,7 @@ import {
   Spinner
 } from "flowbite-react";
 import { useEffect, useState } from "react";
-import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
+import { COUNTRIES, getCountry, isIndia, isOther, isValidCustomCode, effectiveCountryCode, detectCountryCode } from "@/utils/countries";
 
 export default function LoginModalv2({
   openLoginModal,
@@ -18,6 +18,7 @@ export default function LoginModalv2({
 }) {
   const [data, setData] = useState({
     countryCode: "+91",
+    customCountryCode: "+",
     phone: "",
     loading: false,
     success: false,
@@ -38,10 +39,15 @@ export default function LoginModalv2({
   }, []);
 
   const country = getCountry(data.countryCode);
+  const effectiveCC = effectiveCountryCode(data.countryCode, data.customCountryCode);
 
   const SendOTP = () => {
     setData({ ...data, loading: true, message: "" });
-    if (isIndia(data.countryCode)) {
+    if (isOther(data.countryCode) && !isValidCustomCode(data.customCountryCode)) {
+      setData({ ...data, loading: false, message: "Enter a valid country code (e.g. +49)" });
+      return;
+    }
+    if (isIndia(effectiveCC)) {
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -66,7 +72,7 @@ export default function LoginModalv2({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phone: data.phone,
-          countryCode: data.countryCode,
+          countryCode: effectiveCC,
         }),
       })
         .then((r) => r.json())
@@ -88,7 +94,7 @@ export default function LoginModalv2({
 
   const handleLogin = () => {
     setData({ ...data, loading: true });
-    if (isIndia(data.countryCode)) {
+    if (isIndia(effectiveCC)) {
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -128,7 +134,7 @@ export default function LoginModalv2({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phone: data.phone,
-          countryCode: data.countryCode,
+          countryCode: effectiveCC,
           otp: data.Otp,
           referenceId: data.ReferenceId,
         }),
@@ -183,7 +189,7 @@ export default function LoginModalv2({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         phone: data.phone,
-        countryCode: data.countryCode,
+        countryCode: effectiveCC,
         name: data.name,
         email: data.email,
         signupToken: data.signupToken,
@@ -222,13 +228,15 @@ export default function LoginModalv2({
       });
   };
 
-  const isPhoneValid = isIndia(data.countryCode)
+  const isPhoneValid = isIndia(effectiveCC)
     ? /^\d{10}$/.test(data.phone)
     : data.phone.length >= Math.min(8, country.digits);
 
+  const customCodeOK = !isOther(data.countryCode) || isValidCustomCode(data.customCountryCode);
+
   const isDisabled = data.needsSignup
     ? !data.name || !data.email || data.loading
-    : !data.phone || !isPhoneValid || data.loading || (data.otpSent ? !data.Otp : false);
+    : !data.phone || !isPhoneValid || !customCodeOK || data.loading || (data.otpSent ? !data.Otp : false);
 
   return (
     <>
@@ -252,11 +260,11 @@ export default function LoginModalv2({
                       value={data.countryCode}
                       onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                       disabled={data.otpSent}
-                      className="w-28 text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                      className="w-[120px] text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
                     >
                       {COUNTRIES.map((c) => (
                         <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                          {c.flag} {c.code}
+                          {c.flag} {isOther(c.code) ? "Other" : c.code}
                         </option>
                       ))}
                     </select>
@@ -272,6 +280,21 @@ export default function LoginModalv2({
                       className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
                     />
                   </div>
+                  {isOther(data.countryCode) && (
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      placeholder="+49"
+                      value={data.customCountryCode}
+                      maxLength={5}
+                      onChange={(e) => {
+                        const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                        setData({ ...data, customCountryCode: "+" + digits });
+                      }}
+                      disabled={data.otpSent}
+                      className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                    />
+                  )}
                   {data.otpSent && (
                     <input
                       type="text"

--- a/components/layout/LoginModalv2.js
+++ b/components/layout/LoginModalv2.js
@@ -4,7 +4,8 @@ import {
   Modal,
   Spinner
 } from "flowbite-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
 
 export default function LoginModalv2({
   openLoginModal,
@@ -16,6 +17,7 @@ export default function LoginModalv2({
   source,
 }) {
   const [data, setData] = useState({
+    countryCode: "+91",
     phone: "",
     loading: false,
     success: false,
@@ -23,79 +25,211 @@ export default function LoginModalv2({
     Otp: "",
     ReferenceId: "",
     message: "",
+    signupToken: "",
+    needsSignup: false,
+    name: "",
+    email: "",
   });
+
+  useEffect(() => {
+    detectCountryCode().then((code) => {
+      setData((d) => ({ ...d, countryCode: code }));
+    });
+  }, []);
+
+  const country = getCountry(data.countryCode);
+
   const SendOTP = () => {
-    setData({
-      ...data,
-      loading: true,
-    });
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        phone: `+91${data.phone}`,
-      }),
-    })
-      .then((response) => response.json())
-      .then((response) => {
-        setData({
-          ...data,
-          loading: false,
-          otpSent: true,
-          ReferenceId: response.ReferenceId,
-        });
+    setData({ ...data, loading: true, message: "" });
+    if (isIndia(data.countryCode)) {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone: `+91${data.phone}` }),
       })
-      .catch((error) => {
-        console.error("There was a problem with the fetch operation:", error);
-      });
+        .then((r) => r.json())
+        .then((response) => {
+          setData({
+            ...data,
+            loading: false,
+            otpSent: true,
+            ReferenceId: response.ReferenceId,
+          });
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    } else {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp/international`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: data.phone,
+          countryCode: data.countryCode,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          setData({
+            ...data,
+            loading: false,
+            otpSent: true,
+            ReferenceId: response.ReferenceId,
+            message: response.message || "OTP sent on WhatsApp",
+          });
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    }
   };
+
   const handleLogin = () => {
-    setData({
-      ...data,
-      loading: true,
-    });
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
+    setData({ ...data, loading: true });
+    if (isIndia(data.countryCode)) {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: `+91${data.phone}`,
+          Otp: data.Otp,
+          ReferenceId: data.ReferenceId,
+          source: source || "",
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          if (response.message === "Login Successful" && response.token) {
+            setData({
+              ...data,
+              phone: "",
+              loading: false,
+              success: true,
+              otpSent: false,
+              Otp: "",
+              ReferenceId: "",
+              message: "",
+            });
+            localStorage.setItem("token", response.token);
+            CheckLogin();
+          } else {
+            setData({ ...data, loading: false, Otp: "", message: response.message });
+          }
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    } else {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/verify/international`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: data.phone,
+          countryCode: data.countryCode,
+          otp: data.Otp,
+          referenceId: data.ReferenceId,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          if (response.userExists && response.token) {
+            localStorage.setItem("token", response.token);
+            setData({
+              ...data,
+              phone: "",
+              loading: false,
+              success: true,
+              otpSent: false,
+              Otp: "",
+              ReferenceId: "",
+              message: "",
+            });
+            CheckLogin();
+          } else if (response.userExists === false && response.signupToken) {
+            setData({
+              ...data,
+              loading: false,
+              needsSignup: true,
+              signupToken: response.signupToken,
+              message: "",
+            });
+          } else {
+            setData({
+              ...data,
+              loading: false,
+              Otp: "",
+              message: response.message || "Invalid or expired OTP",
+            });
+          }
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    }
+  };
+
+  const handleSignup = () => {
+    if (!data.name || !data.email) {
+      setData({ ...data, message: "Name and email are required" });
+      return;
+    }
+    setData({ ...data, loading: true });
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup/international`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        phone: `+91${data.phone}`,
-        Otp: data.Otp,
-        ReferenceId: data.ReferenceId,
-        source: source || "",
+        phone: data.phone,
+        countryCode: data.countryCode,
+        name: data.name,
+        email: data.email,
+        signupToken: data.signupToken,
       }),
     })
-      .then((response) => response.json())
+      .then((r) => r.json())
       .then((response) => {
-        if (response.message === "Login Successful" && response.token) {
+        if (response.token) {
+          localStorage.setItem("token", response.token);
           setData({
             ...data,
             phone: "",
             loading: false,
             success: true,
             otpSent: false,
+            needsSignup: false,
             Otp: "",
             ReferenceId: "",
+            signupToken: "",
+            name: "",
+            email: "",
             message: "",
           });
-          localStorage.setItem("token", response.token);
           CheckLogin();
         } else {
           setData({
             ...data,
             loading: false,
-            Otp: "",
-            message: response.message,
+            message: response.message || "Account creation failed",
           });
         }
       })
       .catch((error) => {
         console.error("There was a problem with the fetch operation:", error);
+        setData({ ...data, loading: false });
       });
   };
+
+  const isPhoneValid = isIndia(data.countryCode)
+    ? /^\d{10}$/.test(data.phone)
+    : data.phone.length >= Math.min(8, country.digits);
+
+  const isDisabled = data.needsSignup
+    ? !data.name || !data.email || data.loading
+    : !data.phone || !isPhoneValid || data.loading || (data.otpSent ? !data.Otp : false);
+
   return (
     <>
       <Modal
@@ -108,50 +242,80 @@ export default function LoginModalv2({
         <Modal.Body>
           <div className="space-y-6">
             <h3 className="text-xl font-medium text-gray-900 dark:text-white text-center">
-              Login to proceed
+              {data.needsSignup ? "Create your account" : "Login to proceed"}
             </h3>
             <div className=" gap-6 flex flex-col w-2/3 mx-auto">
-              <input
-                type="text"
-                placeholder="PHONE NO."
-                value={data.phone}
-                onChange={(e) =>
-                  setData({
-                    ...data,
-                    phone: e.target.value,
-                  })
-                }
-                name="phone"
-                className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 outline-0 placeholder:text-black"
-              />
-              {data.otpSent && (
-                <input
-                  type="text"
-                  placeholder="OTP"
-                  value={data.Otp}
-                  onChange={(e) =>
-                    setData({
-                      ...data,
-                      Otp: e.target.value,
-                    })
-                  }
-                  name="otp"
-                  className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 outline-0 placeholder:text-black"
-                />
+              {!data.needsSignup && (
+                <>
+                  <div className="flex gap-2">
+                    <select
+                      value={data.countryCode}
+                      onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                      disabled={data.otpSent}
+                      className="text-black bg-transparent border-0 border-b border-b-black focus:ring-0"
+                    >
+                      {COUNTRIES.map((c) => (
+                        <option key={`${c.code}-${c.name}`} value={c.code}>
+                          {c.flag} {c.code}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      type="tel"
+                      inputMode="numeric"
+                      placeholder={`${country.digits} digits`}
+                      value={data.phone}
+                      maxLength={country.digits}
+                      onChange={(e) => setData({ ...data, phone: e.target.value.replace(/\D/g, "") })}
+                      disabled={data.otpSent}
+                      name="phone"
+                      className="flex-1 min-w-0 focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                    />
+                  </div>
+                  {data.otpSent && (
+                    <input
+                      type="text"
+                      placeholder="OTP"
+                      value={data.Otp}
+                      onChange={(e) => setData({ ...data, Otp: e.target.value })}
+                      name="otp"
+                      className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 outline-0 placeholder:text-black"
+                    />
+                  )}
+                </>
+              )}
+              {data.needsSignup && (
+                <>
+                  <input
+                    type="text"
+                    placeholder="Name"
+                    value={data.name}
+                    onChange={(e) => setData({ ...data, name: e.target.value })}
+                    className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                  />
+                  <input
+                    type="email"
+                    placeholder="Email"
+                    value={data.email}
+                    onChange={(e) => setData({ ...data, email: e.target.value })}
+                    className="focus:ring-0 text-center text-black bg-transparent border-0 border-b border-b-black outline-0 placeholder:text-black"
+                  />
+                </>
               )}
               {data.message && <p className="text-red-500">{data.message}</p>}
             </div>
             <button
               type="submit"
               className="rounded-full bg-black text-white py-2 block w-3/4 mx-auto disabled:bg-black/50"
-              disabled={
-                !data.phone ||
-                !/^\d{10}$/.test(data.phone) ||
-                data.loading ||
-                (data.otpSent ? !data.Otp : false)
-              }
+              disabled={isDisabled}
               onClick={() => {
-                data.otpSent ? handleLogin() : SendOTP();
+                if (data.needsSignup) {
+                  handleSignup();
+                } else if (data.otpSent) {
+                  handleLogin();
+                } else {
+                  SendOTP();
+                }
               }}
             >
               {data.loading ? (
@@ -159,6 +323,8 @@ export default function LoginModalv2({
                   <Spinner size="sm" />
                   <span className="pl-3">Loading...</span>
                 </>
+              ) : data.needsSignup ? (
+                <>Create account</>
               ) : (
                 <>Login</>
               )}

--- a/components/screens/SimilarDecor.js
+++ b/components/screens/SimilarDecor.js
@@ -1,78 +1,25 @@
 import DecorCard from "../cards/DecorCard";
-import Masonry from 'react-masonry-css';
-const gridClasses = [
-  "md:col-span-2 md:row-span-2",
-  "md:col-span-4 md:row-span-2 md:col-start-3",
-  "md:col-span-2 md:row-span-2 md:col-start-7",
-  "md:col-span-2 md:row-span-2 md:row-start-3",
-  "md:col-span-3 md:row-span-2 md:col-start-3 md:row-start-3",
-  "md:col-span-3 md:row-span-2 md:col-start-6 md:row-start-3",
-  "md:col-span-4 md:row-span-3 md:row-start-5",
-  "md:col-span-4 md:row-span-3 md:col-start-5 md:row-start-5",
-  "md:col-span-4 md:row-span-2 md:row-start-8",
-  "md:col-span-4 md:row-span-2 md:col-start-5 md:row-start-8",
-  "md:col-span-3 md:row-span-2 md:row-start-10",
-  "md:col-span-4 md:row-span-2 md:col-start-4 md:row-start-10",
-  "md:col-span-4 md:row-span-2 md:row-start-12",
-  "md:col-span-3 md:row-span-2 md:col-start-5 md:row-start-12",
-];
+import Masonry from "react-masonry-css";
 
-const mobileGridClasses = [
-  "min-h-[160px]",
-  "row-span-2 min-h-[240px]",
-  "row-span-2 min-h-[240px]",
-  "col-start-2 row-start-3 min-h-[160px]",
-  "row-start-4 min-h-[160px]",
-  "row-span-2 row-start-4 min-h-[240px]",
-  "row-span-2 row-start-5 min-h-[240px]",
-  "col-start-2 row-start-6 min-h-[160px]",
-  "row-start-7 min-h-[160px]",
-  "row-span-2 row-start-7 min-h-[240px]",
-  "row-span-2 row-start-8 min-h-[240px]",
-  "col-start-2 row-start-9 min-h-[160px]",
-  "col-span-2 row-span-2 row-start-10 min-h-[280px]",
-  "",
-];
+const breakpointCols = { default: 4, 1280: 4, 1024: 3, 768: 2, 500: 2 };
 
 export default function SimilarDecor({ similarDecor }) {
-  // Define breakpoints for the masonry component
-  const breakpointColumnsObj = {
-    default: 2, // default number of columns
-  };
+  if (!similarDecor?.length) return null;
   return (
-    <div className=" p-8 bg-[#F4F4F4]">
-      <p className="text-2xl font-semibold px-12 text-center">
-        BROWSE MORE DECOR{" "}
-      </p>
-         {/* Mobile grid */}
-        <div className="block md:hidden my-6">
-          <Masonry
-            breakpointCols={breakpointColumnsObj}
-            className="my-masonry-grid"
-            columnClassName="my-masonry-grid_column"
-          >
-            {similarDecor.map((item, index) => (
-              <div key={item._id || index}>
-                {/* Conditionally pass the 'size' prop based on the item's index */}
-                <DecorCard decor={item} size={(index % 4 === 0 || index % 4 === 3) ? 'small' : 'normal'} />
-              </div>
-            ))}
-          </Masonry>
-        </div>
-
-      {/* Desktop grid */}
-      <div className="hidden md:grid grid-cols-2 sm:grid-cols-3 md:grid-cols-8 md:grid-rows-13 gap-2 md:gap-4  my-6 px-4 md:px-12">
-        {similarDecor.map((item, index) => (
-          <div
-            key={item._id || index}
-            className={
-              gridClasses[index] ||
-              "col-span-1 sm:col-span-1 md:col-span-3 md:row-span-2"
-            }
-          >
-            <DecorCard decor={item} />
-          </div>
-        ))}
+    <div className="p-8 bg-[#F4F4F4]">
+      <p className="text-2xl font-semibold px-12 text-center">BROWSE SIMILAR DECOR</p>
+      <div className="my-6">
+        <Masonry
+          breakpointCols={breakpointCols}
+          className="my-masonry-grid"
+          columnClassName="my-masonry-grid_column"
+        >
+          {similarDecor.map((item, index) => (
+            <div key={item._id || index}>
+              <DecorCard decor={item} size={index % 4 === 0 || index % 4 === 3 ? "small" : "normal"} />
+            </div>
+          ))}
+        </Masonry>
       </div>
     </div>
   );

--- a/hooks/useProfileData.js
+++ b/hooks/useProfileData.js
@@ -78,7 +78,8 @@ export default function useProfileData({ token }) {
   }, [token, loadMilestones]);
 
   const refetchMilestones = useCallback(() => {
-    if (event?._id) loadMilestones(event._id);
+    if (event?._id) return loadMilestones(event._id);
+    return Promise.resolve();
   }, [event, loadMilestones]);
 
   return {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,0 +1,58 @@
+import { io } from "socket.io-client";
+
+let socket = null;
+
+/**
+ * Connect (or return the existing) singleton Socket.io client.
+ * Uses the JWT in localStorage('token') for auth.
+ */
+export function connectSocket() {
+  if (typeof window === "undefined") return null;
+  if (socket && socket.connected) return socket;
+
+  const token = localStorage.getItem("token");
+  if (!token) return null;
+
+  const url = process.env.NEXT_PUBLIC_API_URL;
+  if (!url) {
+    console.error("[socket] NEXT_PUBLIC_API_URL is not set");
+    return null;
+  }
+
+  if (socket) {
+    socket.auth = { token };
+    socket.connect();
+    return socket;
+  }
+
+  socket = io(url, {
+    transports: ["websocket"],
+    auth: { token },
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 2000,
+    reconnectionDelayMax: 10000,
+  });
+
+  socket.on("connect", () => console.log("[socket] connected", socket.id));
+  socket.on("disconnect", (reason) =>
+    console.log("[socket] disconnected:", reason)
+  );
+  socket.on("connect_error", (err) =>
+    console.warn("[socket] connect_error:", err?.message || err)
+  );
+
+  return socket;
+}
+
+export function disconnectSocket() {
+  if (socket) {
+    socket.removeAllListeners();
+    socket.disconnect();
+    socket = null;
+  }
+}
+
+export function getSocket() {
+  return socket;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "framer-motion": "^12.34.0",
         "lucide-react": "^0.562.0",
         "next": "^13.5.11",
+        "nprogress": "^0.2.0",
         "postcss": "8.4.29",
         "react": "18.2.0",
         "react-day-picker": "^9.13.0",
@@ -3897,6 +3898,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-icons": "^4.11.0",
         "react-masonry-css": "^1.0.16",
         "react-web-share": "^2.0.2",
+        "socket.io-client": "^4.8.3",
         "tailwindcss": "3.3.3"
       }
     },
@@ -556,6 +557,12 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
+      "license": "MIT"
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1819,6 +1826,28 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -4868,6 +4897,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5885,6 +5942,35 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "^12.34.0",
     "lucide-react": "^0.562.0",
     "next": "^13.5.11",
+    "nprogress": "^0.2.0",
     "postcss": "8.4.29",
     "react": "18.2.0",
     "react-day-picker": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-icons": "^4.11.0",
     "react-masonry-css": "^1.0.16",
     "react-web-share": "^2.0.2",
+    "socket.io-client": "^4.8.3",
     "tailwindcss": "3.3.3"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,10 +8,13 @@ import { BiddingPageSkeleton, MakeupAndBeautyPageSkeleton, MakeupArtistsPageSkel
 import { DecorPageSkeleton } from "@/components/skeletons/wedding-store";
 import "@/styles/globals.css";
 import { trimTitle, trimDescription, OG_IMAGES } from "@/utils/seo";
+import { AnimatePresence, motion } from "framer-motion";
 import { Spinner } from "flowbite-react";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import Script from "next/script";
+import NProgress from "nprogress";
+import "nprogress/nprogress.css";
 import { useEffect, useState } from "react";
 
 function App({ Component, pageProps }) {
@@ -77,6 +80,20 @@ function App({ Component, pageProps }) {
   }, []);
 
   useEffect(() => {
+    NProgress.configure({ showSpinner: false });
+    const handleStart = () => NProgress.start();
+    const handleDone = () => NProgress.done();
+    router.events.on("routeChangeStart", handleStart);
+    router.events.on("routeChangeComplete", handleDone);
+    router.events.on("routeChangeError", handleDone);
+    return () => {
+      router.events.off("routeChangeStart", handleStart);
+      router.events.off("routeChangeComplete", handleDone);
+      router.events.off("routeChangeError", handleDone);
+    };
+  }, [router.events]);
+
+  useEffect(() => {
     // This logic ensures the Meta Pixel script runs correctly on client-side navigation.
     const handleRouteChange = () => {
       import("react-facebook-pixel")
@@ -93,7 +110,7 @@ function App({ Component, pageProps }) {
         ReactPixel.pageView();
         router.events.on("routeChangeComplete", handleRouteChange);
       });
-    
+
     // This is the cleanup function to prevent memory leaks as recommended.
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
@@ -269,25 +286,35 @@ function App({ Component, pageProps }) {
           <LoginModal openLoginModal={openLoginModal} setOpenLoginModal={setOpenLoginModal} user={user} logIn={logIn} setLogIn={setLogIn} CheckLogin={CheckLogin} />
           <LoginModalv2 openLoginModal={openLoginModalv2} setOpenLoginModal={setOpenLoginModalv2} user={user} logIn={logIn} setLogIn={setLogIn} CheckLogin={CheckLogin} source={loginSource} />
           <main className="flex-grow">
-            {loading ? (
-              router.pathname === '/makeup-and-beauty' ? (
-                <MakeupAndBeautyPageSkeleton />
-              ) : router.pathname.startsWith('/makeup-and-beauty/wedsy-packages') ? (
-                <WedsyPackagesPageSkeleton />
-              ) : router.pathname.startsWith('/makeup-and-beauty/artists') ? (
-                <MakeupArtistsPageSkeleton />
-              ) : router.pathname.startsWith('/makeup-and-beauty/bidding') ? (
-                <BiddingPageSkeleton />
-              ) : router.pathname === '/event' ? (
-                <EventPageSkeleton formStep={1} />
-              ) : router.pathname === '/decor' ? (
-                <DecorPageSkeleton />
-              ) : (
-                <div className="grid place-content-center h-screen "><Spinner size="xl" /></div>
-              )
-            ) : (
-              <Component {...pageProps} userLoggedIn={!logIn} user={user} setOpenLoginModal={setOpenLoginModal} setOpenLoginModalv2={setOpenLoginModalv2} CheckLogin={CheckLogin} setSource={setLoginSource} />
-            )}
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={router.asPath}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              >
+                {loading ? (
+                  router.pathname === '/makeup-and-beauty' ? (
+                    <MakeupAndBeautyPageSkeleton />
+                  ) : router.pathname.startsWith('/makeup-and-beauty/wedsy-packages') ? (
+                    <WedsyPackagesPageSkeleton />
+                  ) : router.pathname.startsWith('/makeup-and-beauty/artists') ? (
+                    <MakeupArtistsPageSkeleton />
+                  ) : router.pathname.startsWith('/makeup-and-beauty/bidding') ? (
+                    <BiddingPageSkeleton />
+                  ) : router.pathname === '/event' ? (
+                    <EventPageSkeleton formStep={1} />
+                  ) : router.pathname === '/decor' ? (
+                    <DecorPageSkeleton />
+                  ) : (
+                    <div className="grid place-content-center h-screen "><Spinner size="xl" /></div>
+                  )
+                ) : (
+                  <Component {...pageProps} userLoggedIn={!logIn} user={user} setOpenLoginModal={setOpenLoginModal} setOpenLoginModalv2={setOpenLoginModalv2} CheckLogin={CheckLogin} setSource={setLoginSource} />
+                )}
+              </motion.div>
+            </AnimatePresence>
           </main>
           <footer className="contents">
             <Footer />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -206,7 +206,7 @@ function App({ Component, pageProps }) {
           </>
         )}
         <link rel="canonical" href={`https://www.wedsy.in${router.asPath === "/" ? "" : router.asPath.split("?")[0].split("#")[0]}`} />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
         <meta httpEquiv="content-type" content="text/html;charset=UTF-8" />
         <meta property="og:locale" content="en_IN" />
         <meta property="og:title" content="Wedsy | Weddings Made Easy" />

--- a/pages/decor/index.js
+++ b/pages/decor/index.js
@@ -17,6 +17,7 @@ function Decor({
   userLoggedIn,
   user,
   spotlightList = [],
+  photoboothDecor = [],
 }) {
   const [spotlightIndex, setSpotlightIndex] = useState(0);
   const spotlightRef = useRef(null);
@@ -894,7 +895,7 @@ function Decor({
                     {[...bestSellerBackdrops.slice(0, 6), ...bestSellerBackdrops.slice(0, 6), ...bestSellerBackdrops.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`backdrops-${index}`} 
-                    className="carousel-item relative group w-[451px] h-[241px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
@@ -1019,7 +1020,7 @@ function Decor({
                 {[...grandEntry.slice(0, 6), ...grandEntry.slice(0, 6), ...grandEntry.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`grandEntry-${index}`} 
-                    className="carousel-item relative group w-[451px] h-[241px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
@@ -1304,7 +1305,7 @@ function Decor({
                     {[...bestSellerMandaps.slice(0, 6), ...bestSellerMandaps.slice(0, 6), ...bestSellerMandaps.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`mandaps-${index}`} 
-                    className="carousel-item relative group w-[451px] h-[241px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
@@ -1429,7 +1430,7 @@ function Decor({
                 {[...furniture.slice(0, 6), ...furniture.slice(0, 6), ...furniture.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`furniture-${index}`} 
-                    className="carousel-item relative group w-[451px] h-[241px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
@@ -1540,149 +1541,103 @@ function Decor({
           <div className="hidden md:block max-w-[1180px] mx-auto px-4">
             <div className="grid grid-cols-3 gap-6">
               {/* Large image on the left */}
-              <div className="col-span-1">
-                <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
-                  <img
-                    src="/assets/decor/photobooth-img/pb1.webp"
-                    alt="Photobooth Design 1"
-                    className="w-full h-[400px] object-cover group-hover:scale-105 transition-transform duration-300"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                  <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                    <h3 className="text-lg font-semibold">Elegant Floral</h3>
-                    <p className="text-sm">Premium Design</p>
+              {photoboothDecor[0] && (
+                <div className="col-span-1">
+                  <Link href={`/decor/view/${photoboothDecor[0]._id}`}>
+                    <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
+                      <img
+                        src={photoboothDecor[0].thumbnail || "/assets/decor/decor-home.webp"}
+                        alt={photoboothDecor[0].name || "Photobooth Design"}
+                        className="w-full h-[400px] object-contain group-hover:scale-105 transition-transform duration-300"
+                      />
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                      <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                        <h3 className="text-lg font-semibold">{photoboothDecor[0].name}</h3>
+                      </div>
+                    </div>
+                  </Link>
+                </div>
+              )}
+
+              {/* Four smaller images on the right */}
+              {photoboothDecor.length > 1 && (
+                <div className="col-span-2 space-y-6">
+                  <div className="grid grid-cols-2 gap-6">
+                    {photoboothDecor.slice(1, 3).map((item) => (
+                      <Link key={item._id} href={`/decor/view/${item._id}`}>
+                        <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
+                          <img
+                            src={item.thumbnail || "/assets/decor/decor-home.webp"}
+                            alt={item.name || "Photobooth Design"}
+                            className="w-full h-[190px] object-contain group-hover:scale-105 transition-transform duration-300"
+                          />
+                          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                          <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                            <h3 className="text-lg font-semibold">{item.name}</h3>
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-2 gap-6">
+                    {photoboothDecor.slice(3, 5).map((item) => (
+                      <Link key={item._id} href={`/decor/view/${item._id}`}>
+                        <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
+                          <img
+                            src={item.thumbnail || "/assets/decor/decor-home.webp"}
+                            alt={item.name || "Photobooth Design"}
+                            className="w-full h-[190px] object-contain group-hover:scale-105 transition-transform duration-300"
+                          />
+                          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                          <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                            <h3 className="text-lg font-semibold">{item.name}</h3>
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
                   </div>
                 </div>
-              </div>
-
-              {/* Two medium images on the right */}
-              <div className="col-span-2 space-y-6">
-                <div className="grid grid-cols-2 gap-6">
-                  <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
-                    <img
-                      src="/assets/decor/photobooth-img/pb2.webp"
-                      alt="Photobooth Design 2"
-                      className="w-full h-[190px] object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                    <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-lg font-semibold">Modern Minimal</h3>
-                      <p className="text-sm">Contemporary Style</p>
-                    </div>
-                  </div>
-
-                  <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
-                    <img
-                      src="/assets/decor/photobooth-img/pb3.webp"
-                      alt="Photobooth Design 3"
-                      className="w-full h-[190px] object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                    <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-lg font-semibold">Royal Gold</h3>
-                      <p className="text-sm">Luxury Theme</p>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Bottom row with two images */}
-                <div className="grid grid-cols-2 gap-6">
-                  <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
-                    <img
-                      src="/assets/decor/photobooth-img/pb4.webp"
-                      alt="Photobooth Design 4"
-                      className="w-full h-[190px] object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                    <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-lg font-semibold">Vintage Charm</h3>
-                      <p className="text-sm">Classic Elegance</p>
-                    </div>
-                  </div>
-
-                  <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
-                    <img
-                      src="/assets/decor/photobooth-img/pb5.webp"
-                      alt="Photobooth Design 5"
-                      className="w-full h-[190px] object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                    <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-lg font-semibold">Nature Inspired</h3>
-                      <p className="text-sm">Organic Beauty</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              )}
             </div>
           </div>
 
           {/* Mobile Grid Layout */}
           <div className="md:hidden px-4">
             <div className="grid grid-cols-2 gap-4">
-              <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
-                <img
-                  src="/assets/decor/photobooth-img/pb1.webp"
-                  alt="Photobooth Design 1"
-                  className="w-full h-[200px] object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <h3 className="text-sm font-semibold">Elegant Floral</h3>
-                </div>
-              </div>
-
-              <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
-                <img
-                  src="/assets/decor/photobooth-img/pb2.webp"
-                  alt="Photobooth Design 2"
-                  className="w-full h-[200px] object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <h3 className="text-sm font-semibold">Modern Minimal</h3>
-                </div>
-              </div>
-
-              <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
-                <img
-                  src="/assets/decor/photobooth-img/pb3.webp"
-                  alt="Photobooth Design 3"
-                  className="w-full h-[200px] object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <h3 className="text-sm font-semibold">Royal Gold</h3>
-                </div>
-              </div>
-
-              <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
-                <img
-                  src="/assets/decor/photobooth-img/pb4.webp"
-                  alt="Photobooth Design 4"
-                  className="w-full h-[200px] object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <h3 className="text-sm font-semibold">Vintage Charm</h3>
-                </div>
-              </div>
-
-              <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300 col-span-2">
-                <img
-                  src="/assets/decor/photobooth-img/pb5.webp"
-                  alt="Photobooth Design 5"
-                  className="w-full h-[200px] object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                  <h3 className="text-sm font-semibold">Nature Inspired</h3>
-                </div>
-              </div>
+              {photoboothDecor.slice(0, 4).map((item) => (
+                <Link key={item._id} href={`/decor/view/${item._id}`}>
+                  <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
+                    <img
+                      src={item.thumbnail || "/assets/decor/decor-home.webp"}
+                      alt={item.name || "Photobooth Design"}
+                      className="w-full h-[200px] object-contain group-hover:scale-105 transition-transform duration-300"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                    <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                      <h3 className="text-sm font-semibold">{item.name}</h3>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+              {photoboothDecor[4] && (
+                <Link href={`/decor/view/${photoboothDecor[4]._id}`} className="col-span-2">
+                  <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
+                    <img
+                      src={photoboothDecor[4].thumbnail || "/assets/decor/decor-home.webp"}
+                      alt={photoboothDecor[4].name || "Photobooth Design"}
+                      className="w-full h-[200px] object-contain group-hover:scale-105 transition-transform duration-300"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                    <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                      <h3 className="text-sm font-semibold">{photoboothDecor[4].name}</h3>
+                    </div>
+                  </div>
+                </Link>
+              )}
             </div>
             <div className="flex justify-center mt-4">
               <Link
-                href="/decor/view"
+                href="/decor/view?category=Photobooth"
                 className="text-[16px] underline text-black font-medium font-['Montserrat']"
               >
                 See More
@@ -2009,6 +1964,7 @@ export async function getServerSideProps(context) {
           furniture: [],
           popular: [],
           spotlightList: [],
+          photoboothDecor: [],
         },
       };
     }
@@ -2038,6 +1994,7 @@ export async function getServerSideProps(context) {
       furnitureData,
       popularData,
       spotlightListData,
+      photoboothDecorData,
     ] = await Promise.all([
       fetchJson(`${apiUrl}/decor?label=bestSeller&category=Stage`),
       fetchJson(`${apiUrl}/decor?category=Entrance`),
@@ -2045,6 +2002,7 @@ export async function getServerSideProps(context) {
       fetchJson(`${apiUrl}/decor?category=Furniture`),
       fetchJson(`${apiUrl}/decor?label=popular`),
       fetchJson(`${apiUrl}/decor?spotlight=true&random=false`),
+      fetchJson(`${apiUrl}/decor?category=Photobooth&limit=5`),
     ]);
 
     const toList = (data) =>
@@ -2055,6 +2013,7 @@ export async function getServerSideProps(context) {
     const furniture = toList(furnitureData);
     const popular = toList(popularData);
     const spotlightList = Array.isArray(spotlightListData?.list) ? spotlightListData.list : [];
+    const photoboothDecor = toList(photoboothDecorData).slice(0, 5);
 
     return {
       props: {
@@ -2064,6 +2023,7 @@ export async function getServerSideProps(context) {
         furniture,
         popular,
         spotlightList,
+        photoboothDecor,
       },
     };
   } catch (error) {
@@ -2076,6 +2036,7 @@ export async function getServerSideProps(context) {
         furniture: [],
         popular: [],
         spotlightList: [],
+        photoboothDecor: [],
       },
     };
   }

--- a/pages/decor/index.js
+++ b/pages/decor/index.js
@@ -75,7 +75,14 @@ function Decor({
     mandaps: false,
     furniture: false
   });
-  
+
+  // Photobooth flip animation
+  const pbTimersRef = useRef([]);
+  const [pbCurrentIdx, setPbCurrentIdx] = useState(
+    Array.from({ length: 5 }, (_, i) => photoboothDecor.length > 0 ? i % photoboothDecor.length : 0)
+  );
+  const [pbMidFlip, setPbMidFlip] = useState(Array(5).fill(false));
+
   // Item width calculation (451px + 24px gap = 475px)
   const itemWidth = 475;
 
@@ -413,6 +420,55 @@ function Decor({
     isPaused,
     itemWidth,
   ]);
+
+  // Photobooth tile flip animation — staggered per tile, repeating every 5s
+  useEffect(() => {
+    pbTimersRef.current.forEach(t => { clearTimeout(t); clearInterval(t); });
+    pbTimersRef.current = [];
+
+    if (photoboothDecor.length < 2) return;
+
+    for (let i = 0; i < 5; i++) {
+      const tileIdx = i;
+
+      const flipTile = () => {
+        // Phase 1: rotate card edge-on (disappears over 350ms)
+        setPbMidFlip(prev => {
+          const next = [...prev];
+          next[tileIdx] = true;
+          return next;
+        });
+        // Phase 2: swap image at midpoint, rotate back to face (appears over 350ms)
+        const swapTimer = setTimeout(() => {
+          setPbCurrentIdx(prev => {
+            const next = [...prev];
+            next[tileIdx] = (next[tileIdx] + 1) % photoboothDecor.length;
+            return next;
+          });
+          setPbMidFlip(prev => {
+            const next = [...prev];
+            next[tileIdx] = false;
+            return next;
+          });
+        }, 380);
+        pbTimersRef.current.push(swapTimer);
+      };
+
+      // Stagger initial flip: tile 0→3s, tile 1→4s, tile 2→5s, tile 3→6s, tile 4→7s
+      const startTimer = setTimeout(() => {
+        flipTile();
+        const repeatTimer = setInterval(flipTile, 5000);
+        pbTimersRef.current.push(repeatTimer);
+      }, (tileIdx + 3) * 1000);
+
+      pbTimersRef.current.push(startTimer);
+    }
+
+    return () => {
+      pbTimersRef.current.forEach(t => { clearTimeout(t); clearInterval(t); });
+      pbTimersRef.current = [];
+    };
+  }, [photoboothDecor.length]);
 
   return (
     <div className="bg-[#F4F4F4] min-h-screen w-full">
@@ -895,13 +951,13 @@ function Decor({
                     {[...bestSellerBackdrops.slice(0, 6), ...bestSellerBackdrops.slice(0, 6), ...bestSellerBackdrops.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`backdrops-${index}`} 
-                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] h-[280px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
                         decor={decor}
-                        className="w-full h-full rounded-[30px] overflow-hidden"
                         hideInfo={true}
+                        fillContainer={true}
                       />
                     </div>
                     {/* Hover overlay for name and price */}
@@ -1020,13 +1076,13 @@ function Decor({
                 {[...grandEntry.slice(0, 6), ...grandEntry.slice(0, 6), ...grandEntry.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`grandEntry-${index}`} 
-                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] h-[280px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
                         decor={decor}
-                        className="w-full h-full rounded-[30px] overflow-hidden"
                         hideInfo={true}
+                        fillContainer={true}
                       />
                     </div>
                     {/* Hover overlay for name and price */}
@@ -1305,13 +1361,13 @@ function Decor({
                     {[...bestSellerMandaps.slice(0, 6), ...bestSellerMandaps.slice(0, 6), ...bestSellerMandaps.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`mandaps-${index}`} 
-                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] h-[280px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
                         decor={decor}
-                        className="w-full h-full rounded-[30px] overflow-hidden"
                         hideInfo={true}
+                        fillContainer={true}
                       />
                     </div>
                     {/* Hover overlay for name and price */}
@@ -1430,13 +1486,13 @@ function Decor({
                 {[...furniture.slice(0, 6), ...furniture.slice(0, 6), ...furniture.slice(0, 6)].map((decor, index) => (
                   <div 
                     key={`furniture-${index}`} 
-                    className="carousel-item relative group w-[451px] max-h-[300px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                    className="carousel-item relative group w-[451px] h-[280px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
                         decor={decor}
-                        className="w-full h-full rounded-[30px] overflow-hidden"
                         hideInfo={true}
+                        fillContainer={true}
                       />
                     </div>
                     {/* Hover overlay for name and price */}
@@ -1540,57 +1596,75 @@ function Decor({
           {/* Desktop Grid Layout */}
           <div className="hidden md:block max-w-[1180px] mx-auto px-4">
             <div className="grid grid-cols-3 gap-6">
-              {/* Large image on the left */}
-              {photoboothDecor[0] && (
+              {/* Large image — tile 0 */}
+              {photoboothDecor.length > 0 && (
                 <div className="col-span-1">
-                  <Link href={`/decor/view/${photoboothDecor[0]._id}`}>
-                    <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
+                  <Link href={`/decor/view/${photoboothDecor[pbCurrentIdx[0]]?._id}`}>
+                    <div
+                      className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-shadow duration-300"
+                      style={{
+                        transform: pbMidFlip[0] ? 'perspective(600px) rotateY(-90deg)' : 'perspective(600px) rotateY(0deg)',
+                        transition: 'transform 0.35s ease-in-out',
+                      }}
+                    >
                       <img
-                        src={photoboothDecor[0].thumbnail || "/assets/decor/decor-home.webp"}
-                        alt={photoboothDecor[0].name || "Photobooth Design"}
-                        className="w-full h-[400px] object-contain group-hover:scale-105 transition-transform duration-300"
+                        src={photoboothDecor[pbCurrentIdx[0]]?.thumbnail || "/assets/decor/decor-home.webp"}
+                        alt={photoboothDecor[pbCurrentIdx[0]]?.name || "Photobooth Design"}
+                        className="w-full h-[400px] object-contain"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                       <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                        <h3 className="text-lg font-semibold">{photoboothDecor[0].name}</h3>
+                        <h3 className="text-lg font-semibold">{photoboothDecor[pbCurrentIdx[0]]?.name}</h3>
                       </div>
                     </div>
                   </Link>
                 </div>
               )}
 
-              {/* Four smaller images on the right */}
+              {/* Four smaller tiles — tiles 1–4 */}
               {photoboothDecor.length > 1 && (
                 <div className="col-span-2 space-y-6">
                   <div className="grid grid-cols-2 gap-6">
-                    {photoboothDecor.slice(1, 3).map((item) => (
-                      <Link key={item._id} href={`/decor/view/${item._id}`}>
-                        <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
+                    {[1, 2].map((tileIdx) => (
+                      <Link key={tileIdx} href={`/decor/view/${photoboothDecor[pbCurrentIdx[tileIdx]]?._id}`}>
+                        <div
+                          className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-shadow duration-300"
+                          style={{
+                            transform: pbMidFlip[tileIdx] ? 'perspective(600px) rotateY(-90deg)' : 'perspective(600px) rotateY(0deg)',
+                            transition: 'transform 0.35s ease-in-out',
+                          }}
+                        >
                           <img
-                            src={item.thumbnail || "/assets/decor/decor-home.webp"}
-                            alt={item.name || "Photobooth Design"}
-                            className="w-full h-[190px] object-contain group-hover:scale-105 transition-transform duration-300"
+                            src={photoboothDecor[pbCurrentIdx[tileIdx]]?.thumbnail || "/assets/decor/decor-home.webp"}
+                            alt={photoboothDecor[pbCurrentIdx[tileIdx]]?.name || "Photobooth Design"}
+                            className="w-full h-[190px] object-contain"
                           />
                           <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                           <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                            <h3 className="text-lg font-semibold">{item.name}</h3>
+                            <h3 className="text-lg font-semibold">{photoboothDecor[pbCurrentIdx[tileIdx]]?.name}</h3>
                           </div>
                         </div>
                       </Link>
                     ))}
                   </div>
                   <div className="grid grid-cols-2 gap-6">
-                    {photoboothDecor.slice(3, 5).map((item) => (
-                      <Link key={item._id} href={`/decor/view/${item._id}`}>
-                        <div className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-all duration-300">
+                    {[3, 4].map((tileIdx) => (
+                      <Link key={tileIdx} href={`/decor/view/${photoboothDecor[pbCurrentIdx[tileIdx]]?._id}`}>
+                        <div
+                          className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-shadow duration-300"
+                          style={{
+                            transform: pbMidFlip[tileIdx] ? 'perspective(600px) rotateY(-90deg)' : 'perspective(600px) rotateY(0deg)',
+                            transition: 'transform 0.35s ease-in-out',
+                          }}
+                        >
                           <img
-                            src={item.thumbnail || "/assets/decor/decor-home.webp"}
-                            alt={item.name || "Photobooth Design"}
-                            className="w-full h-[190px] object-contain group-hover:scale-105 transition-transform duration-300"
+                            src={photoboothDecor[pbCurrentIdx[tileIdx]]?.thumbnail || "/assets/decor/decor-home.webp"}
+                            alt={photoboothDecor[pbCurrentIdx[tileIdx]]?.name || "Photobooth Design"}
+                            className="w-full h-[190px] object-contain"
                           />
                           <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                           <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                            <h3 className="text-lg font-semibold">{item.name}</h3>
+                            <h3 className="text-lg font-semibold">{photoboothDecor[pbCurrentIdx[tileIdx]]?.name}</h3>
                           </div>
                         </div>
                       </Link>
@@ -1604,32 +1678,46 @@ function Decor({
           {/* Mobile Grid Layout */}
           <div className="md:hidden px-4">
             <div className="grid grid-cols-2 gap-4">
-              {photoboothDecor.slice(0, 4).map((item) => (
-                <Link key={item._id} href={`/decor/view/${item._id}`}>
-                  <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
+              {/* Tiles 0–3 */}
+              {photoboothDecor.length > 0 && [0, 1, 2, 3].map((tileIdx) => (
+                <Link key={tileIdx} href={`/decor/view/${photoboothDecor[pbCurrentIdx[tileIdx]]?._id}`}>
+                  <div
+                    className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg"
+                    style={{
+                      transform: pbMidFlip[tileIdx] ? 'perspective(600px) rotateY(-90deg)' : 'perspective(600px) rotateY(0deg)',
+                      transition: 'transform 0.35s ease-in-out',
+                    }}
+                  >
                     <img
-                      src={item.thumbnail || "/assets/decor/decor-home.webp"}
-                      alt={item.name || "Photobooth Design"}
-                      className="w-full h-[200px] object-contain group-hover:scale-105 transition-transform duration-300"
+                      src={photoboothDecor[pbCurrentIdx[tileIdx]]?.thumbnail || "/assets/decor/decor-home.webp"}
+                      alt={photoboothDecor[pbCurrentIdx[tileIdx]]?.name || "Photobooth Design"}
+                      className="w-full h-[200px] object-contain"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-sm font-semibold">{item.name}</h3>
+                      <h3 className="text-sm font-semibold">{photoboothDecor[pbCurrentIdx[tileIdx]]?.name}</h3>
                     </div>
                   </div>
                 </Link>
               ))}
-              {photoboothDecor[4] && (
-                <Link href={`/decor/view/${photoboothDecor[4]._id}`} className="col-span-2">
-                  <div className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg hover:shadow-xl transition-all duration-300">
+              {/* Tile 4 — full width */}
+              {photoboothDecor.length > 0 && (
+                <Link href={`/decor/view/${photoboothDecor[pbCurrentIdx[4]]?._id}`} className="col-span-2">
+                  <div
+                    className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg"
+                    style={{
+                      transform: pbMidFlip[4] ? 'perspective(600px) rotateY(-90deg)' : 'perspective(600px) rotateY(0deg)',
+                      transition: 'transform 0.35s ease-in-out',
+                    }}
+                  >
                     <img
-                      src={photoboothDecor[4].thumbnail || "/assets/decor/decor-home.webp"}
-                      alt={photoboothDecor[4].name || "Photobooth Design"}
-                      className="w-full h-[200px] object-contain group-hover:scale-105 transition-transform duration-300"
+                      src={photoboothDecor[pbCurrentIdx[4]]?.thumbnail || "/assets/decor/decor-home.webp"}
+                      alt={photoboothDecor[pbCurrentIdx[4]]?.name || "Photobooth Design"}
+                      className="w-full h-[200px] object-contain"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-sm font-semibold">{photoboothDecor[4].name}</h3>
+                      <h3 className="text-sm font-semibold">{photoboothDecor[pbCurrentIdx[4]]?.name}</h3>
                     </div>
                   </div>
                 </Link>

--- a/pages/decor/index.js
+++ b/pages/decor/index.js
@@ -17,7 +17,6 @@ function Decor({
   userLoggedIn,
   user,
   spotlightList = [],
-  photoboothDecor = [],
   allCategories = [],
 }) {
   const [spotlightIndex, setSpotlightIndex] = useState(0);
@@ -71,13 +70,14 @@ function Decor({
 
   // Photobooth flip animation
   const pbTimersRef = useRef([]);
-  const [pbCurrentIdx, setPbCurrentIdx] = useState(
-    Array.from({ length: 5 }, (_, i) => photoboothDecor.length > 0 ? i % photoboothDecor.length : 0)
-  );
+  const pbProductsRef = useRef(Array(5).fill(null));
+  const [pbProducts, setPbProducts] = useState(Array(5).fill(null));
   const [pbMidFlip, setPbMidFlip] = useState(Array(5).fill(false));
 
   // Item width calculation (451px + 24px gap = 475px)
   const itemWidth = 475;
+  // Portrait item width for Grand Entrance and Furniture (280px + 24px gap = 304px)
+  const portraitItemWidth = 304;
 
   const handleEnquiry = () => {
     setEnquiryForm({
@@ -373,7 +373,7 @@ function Decor({
           const len = Math.min(grandEntry.length, 6);
           updates.grandEntry = (prev) => {
             let newX = prev - movementToApply;
-            if (newX <= -len * itemWidth) newX += len * itemWidth;
+            if (newX <= -len * portraitItemWidth) newX += len * portraitItemWidth;
             return newX;
           };
         }
@@ -389,7 +389,7 @@ function Decor({
           const len = Math.min(furniture.length, 6);
           updates.furniture = (prev) => {
             let newX = prev - movementToApply;
-            if (newX <= -len * itemWidth) newX += len * itemWidth;
+            if (newX <= -len * portraitItemWidth) newX += len * portraitItemWidth;
             return newX;
           };
         }
@@ -414,46 +414,75 @@ function Decor({
     itemWidth,
   ]);
 
-  // Photobooth tile flip animation — staggered per tile, repeating every 5s
+  // Photobooth — fetch initial products on mount
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?category=Photobooth&limit=20`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        const items = Array.isArray(data?.list) ? data.list : [];
+        if (items.length === 0) return;
+        const shuffled = [...items].sort(() => Math.random() - 0.5);
+        const initial = Array.from({ length: 5 }, (_, i) => shuffled[i % shuffled.length]);
+        pbProductsRef.current = initial;
+        setPbProducts([...initial]);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Photobooth tile flip animation — fetches a fresh product before each flip
   useEffect(() => {
     pbTimersRef.current.forEach(t => { clearTimeout(t); clearInterval(t); });
     pbTimersRef.current = [];
 
-    if (photoboothDecor.length < 2) return;
+    const fetchAndFlip = async (tileIdx) => {
+      // Phase 1: rotate card edge-on (disappears over 350ms)
+      setPbMidFlip(prev => {
+        const next = [...prev];
+        next[tileIdx] = true;
+        return next;
+      });
 
-    for (let i = 0; i < 5; i++) {
-      const tileIdx = i;
+      // Fetch fresh pool during the rotate-out animation
+      let newProduct = null;
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?category=Photobooth&limit=20`);
+        if (res.ok) {
+          const data = await res.json();
+          const items = Array.isArray(data?.list) ? data.list : [];
+          const currentIds = new Set(pbProductsRef.current.filter(Boolean).map(p => p._id));
+          const candidates = items.filter(item => !currentIds.has(item._id));
+          const pool = candidates.length > 0 ? candidates : items;
+          if (pool.length > 0) {
+            newProduct = pool[Math.floor(Math.random() * pool.length)];
+          }
+        }
+      } catch {}
 
-      const flipTile = () => {
-        // Phase 1: rotate card edge-on (disappears over 350ms)
+      // Phase 2: swap product at midpoint, rotate back to face (appears over 350ms)
+      const swapTimer = setTimeout(() => {
+        if (newProduct) {
+          const nextProds = [...pbProductsRef.current];
+          nextProds[tileIdx] = newProduct;
+          pbProductsRef.current = nextProds;
+          setPbProducts([...nextProds]);
+        }
         setPbMidFlip(prev => {
           const next = [...prev];
-          next[tileIdx] = true;
+          next[tileIdx] = false;
           return next;
         });
-        // Phase 2: swap image at midpoint, rotate back to face (appears over 350ms)
-        const swapTimer = setTimeout(() => {
-          setPbCurrentIdx(prev => {
-            const next = [...prev];
-            next[tileIdx] = (next[tileIdx] + 1) % photoboothDecor.length;
-            return next;
-          });
-          setPbMidFlip(prev => {
-            const next = [...prev];
-            next[tileIdx] = false;
-            return next;
-          });
-        }, 380);
-        pbTimersRef.current.push(swapTimer);
-      };
+      }, 380);
+      pbTimersRef.current.push(swapTimer);
+    };
 
-      // Stagger initial flip: tile 0→3s, tile 1→4s, tile 2→5s, tile 3→6s, tile 4→7s
+    // Stagger initial flip: tile 0→3s, tile 1→4s, tile 2→5s, tile 3→6s, tile 4→7s
+    for (let i = 0; i < 5; i++) {
+      const tileIdx = i;
       const startTimer = setTimeout(() => {
-        flipTile();
-        const repeatTimer = setInterval(flipTile, 5000);
+        fetchAndFlip(tileIdx);
+        const repeatTimer = setInterval(() => fetchAndFlip(tileIdx), 5000);
         pbTimersRef.current.push(repeatTimer);
       }, (tileIdx + 3) * 1000);
-
       pbTimersRef.current.push(startTimer);
     }
 
@@ -461,7 +490,7 @@ function Decor({
       pbTimersRef.current.forEach(t => { clearTimeout(t); clearInterval(t); });
       pbTimersRef.current = [];
     };
-  }, [photoboothDecor.length]);
+  }, []);
 
   return (
     <div className="bg-[#F4F4F4] min-h-screen w-full">
@@ -1061,11 +1090,11 @@ function Decor({
             }}
           >
             <div className="flex gap-6 justify-center w-full overflow-hidden carousel-container">
-              <div className="flex gap-6" style={{ transform: `translateX(${grandEntryTranslateX}px)`, width: `${Math.min(grandEntry.length, 6) * 3 * itemWidth}px` }}>
+              <div className="flex gap-6" style={{ transform: `translateX(${grandEntryTranslateX}px)`, width: `${Math.min(grandEntry.length, 6) * 3 * portraitItemWidth}px` }}>
                 {[...grandEntry.slice(0, 6), ...grandEntry.slice(0, 6), ...grandEntry.slice(0, 6)].map((decor, index) => (
-                  <div 
-                    key={`grandEntry-${index}`} 
-                    className="carousel-item relative group w-[451px] h-[280px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                  <div
+                    key={`grandEntry-${index}`}
+                    className="carousel-item relative group w-[280px] h-[380px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
@@ -1471,11 +1500,11 @@ function Decor({
             }}
           >
             <div className="flex gap-6 justify-center w-full overflow-hidden carousel-container">
-              <div className="flex gap-6" style={{ transform: `translateX(${furnitureTranslateX}px)`, width: `${Math.min(furniture.length, 6) * 3 * itemWidth}px` }}>
+              <div className="flex gap-6" style={{ transform: `translateX(${furnitureTranslateX}px)`, width: `${Math.min(furniture.length, 6) * 3 * portraitItemWidth}px` }}>
                 {[...furniture.slice(0, 6), ...furniture.slice(0, 6), ...furniture.slice(0, 6)].map((decor, index) => (
-                  <div 
-                    key={`furniture-${index}`} 
-                    className="carousel-item relative group w-[451px] h-[280px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
+                  <div
+                    key={`furniture-${index}`}
+                    className="carousel-item relative group w-[280px] h-[380px] rounded-[30px] overflow-hidden transition-all duration-700 ease-in-out transform hover:scale-105 flex-shrink-0"
                   >
                     <div className="w-full h-full transition-transform duration-300 group-hover:scale-105">
                       <DecorCard
@@ -1586,9 +1615,9 @@ function Decor({
           <div className="hidden md:block max-w-[1180px] mx-auto px-4">
             <div className="grid grid-cols-3 gap-6">
               {/* Large image — tile 0 */}
-              {photoboothDecor.length > 0 && (
+              {pbProducts[0] != null && (
                 <div className="col-span-1">
-                  <Link href={`/decor/view/${photoboothDecor[pbCurrentIdx[0]]?._id}`}>
+                  <Link href={`/decor/view/${pbProducts[0]?._id}`}>
                     <div
                       className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-shadow duration-300"
                       style={{
@@ -1597,13 +1626,13 @@ function Decor({
                       }}
                     >
                       <img
-                        src={photoboothDecor[pbCurrentIdx[0]]?.thumbnail || "/assets/decor/decor-home.webp"}
-                        alt={photoboothDecor[pbCurrentIdx[0]]?.name || "Photobooth Design"}
+                        src={pbProducts[0]?.thumbnail || "/assets/decor/decor-home.webp"}
+                        alt={pbProducts[0]?.name || "Photobooth Design"}
                         className="w-full h-[400px] object-contain"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                       <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                        <h3 className="text-lg font-semibold">{photoboothDecor[pbCurrentIdx[0]]?.name}</h3>
+                        <h3 className="text-lg font-semibold">{pbProducts[0]?.name}</h3>
                       </div>
                     </div>
                   </Link>
@@ -1611,11 +1640,11 @@ function Decor({
               )}
 
               {/* Four smaller tiles — tiles 1–4 */}
-              {photoboothDecor.length > 1 && (
+              {pbProducts[1] != null && (
                 <div className="col-span-2 space-y-6">
                   <div className="grid grid-cols-2 gap-6">
                     {[1, 2].map((tileIdx) => (
-                      <Link key={tileIdx} href={`/decor/view/${photoboothDecor[pbCurrentIdx[tileIdx]]?._id}`}>
+                      <Link key={tileIdx} href={`/decor/view/${pbProducts[tileIdx]?._id}`}>
                         <div
                           className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-shadow duration-300"
                           style={{
@@ -1624,13 +1653,13 @@ function Decor({
                           }}
                         >
                           <img
-                            src={photoboothDecor[pbCurrentIdx[tileIdx]]?.thumbnail || "/assets/decor/decor-home.webp"}
-                            alt={photoboothDecor[pbCurrentIdx[tileIdx]]?.name || "Photobooth Design"}
+                            src={pbProducts[tileIdx]?.thumbnail || "/assets/decor/decor-home.webp"}
+                            alt={pbProducts[tileIdx]?.name || "Photobooth Design"}
                             className="w-full h-[190px] object-contain"
                           />
                           <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                           <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                            <h3 className="text-lg font-semibold">{photoboothDecor[pbCurrentIdx[tileIdx]]?.name}</h3>
+                            <h3 className="text-lg font-semibold">{pbProducts[tileIdx]?.name}</h3>
                           </div>
                         </div>
                       </Link>
@@ -1638,7 +1667,7 @@ function Decor({
                   </div>
                   <div className="grid grid-cols-2 gap-6">
                     {[3, 4].map((tileIdx) => (
-                      <Link key={tileIdx} href={`/decor/view/${photoboothDecor[pbCurrentIdx[tileIdx]]?._id}`}>
+                      <Link key={tileIdx} href={`/decor/view/${pbProducts[tileIdx]?._id}`}>
                         <div
                           className="relative group cursor-pointer overflow-hidden rounded-[20px] shadow-lg hover:shadow-xl transition-shadow duration-300"
                           style={{
@@ -1647,13 +1676,13 @@ function Decor({
                           }}
                         >
                           <img
-                            src={photoboothDecor[pbCurrentIdx[tileIdx]]?.thumbnail || "/assets/decor/decor-home.webp"}
-                            alt={photoboothDecor[pbCurrentIdx[tileIdx]]?.name || "Photobooth Design"}
+                            src={pbProducts[tileIdx]?.thumbnail || "/assets/decor/decor-home.webp"}
+                            alt={pbProducts[tileIdx]?.name || "Photobooth Design"}
                             className="w-full h-[190px] object-contain"
                           />
                           <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                           <div className="absolute bottom-4 left-4 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                            <h3 className="text-lg font-semibold">{photoboothDecor[pbCurrentIdx[tileIdx]]?.name}</h3>
+                            <h3 className="text-lg font-semibold">{pbProducts[tileIdx]?.name}</h3>
                           </div>
                         </div>
                       </Link>
@@ -1668,8 +1697,8 @@ function Decor({
           <div className="md:hidden px-4">
             <div className="grid grid-cols-2 gap-4">
               {/* Tiles 0–3 */}
-              {photoboothDecor.length > 0 && [0, 1, 2, 3].map((tileIdx) => (
-                <Link key={tileIdx} href={`/decor/view/${photoboothDecor[pbCurrentIdx[tileIdx]]?._id}`}>
+              {pbProducts[0] != null && [0, 1, 2, 3].map((tileIdx) => (
+                <Link key={tileIdx} href={`/decor/view/${pbProducts[tileIdx]?._id}`}>
                   <div
                     className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg"
                     style={{
@@ -1678,20 +1707,20 @@ function Decor({
                     }}
                   >
                     <img
-                      src={photoboothDecor[pbCurrentIdx[tileIdx]]?.thumbnail || "/assets/decor/decor-home.webp"}
-                      alt={photoboothDecor[pbCurrentIdx[tileIdx]]?.name || "Photobooth Design"}
+                      src={pbProducts[tileIdx]?.thumbnail || "/assets/decor/decor-home.webp"}
+                      alt={pbProducts[tileIdx]?.name || "Photobooth Design"}
                       className="w-full h-[200px] object-contain"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-sm font-semibold">{photoboothDecor[pbCurrentIdx[tileIdx]]?.name}</h3>
+                      <h3 className="text-sm font-semibold">{pbProducts[tileIdx]?.name}</h3>
                     </div>
                   </div>
                 </Link>
               ))}
               {/* Tile 4 — full width */}
-              {photoboothDecor.length > 0 && (
-                <Link href={`/decor/view/${photoboothDecor[pbCurrentIdx[4]]?._id}`} className="col-span-2">
+              {pbProducts[0] != null && (
+                <Link href={`/decor/view/${pbProducts[4]?._id}`} className="col-span-2">
                   <div
                     className="relative group cursor-pointer overflow-hidden rounded-[15px] shadow-lg"
                     style={{
@@ -1700,13 +1729,13 @@ function Decor({
                     }}
                   >
                     <img
-                      src={photoboothDecor[pbCurrentIdx[4]]?.thumbnail || "/assets/decor/decor-home.webp"}
-                      alt={photoboothDecor[pbCurrentIdx[4]]?.name || "Photobooth Design"}
+                      src={pbProducts[4]?.thumbnail || "/assets/decor/decor-home.webp"}
+                      alt={pbProducts[4]?.name || "Photobooth Design"}
                       className="w-full h-[200px] object-contain"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                     <div className="absolute bottom-3 left-3 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                      <h3 className="text-sm font-semibold">{photoboothDecor[pbCurrentIdx[4]]?.name}</h3>
+                      <h3 className="text-sm font-semibold">{pbProducts[4]?.name}</h3>
                     </div>
                   </div>
                 </Link>
@@ -2072,7 +2101,6 @@ export async function getServerSideProps(context) {
       furnitureData,
       popularData,
       spotlightListData,
-      photoboothDecorData,
       allCategoriesData,
     ] = await Promise.all([
       fetchJson(`${apiUrl}/decor?label=bestSeller&category=Stage`),
@@ -2081,7 +2109,6 @@ export async function getServerSideProps(context) {
       fetchJson(`${apiUrl}/decor?category=Furniture`),
       fetchJson(`${apiUrl}/decor?label=popular`),
       fetchJson(`${apiUrl}/decor?spotlight=true&random=false`),
-      fetchJson(`${apiUrl}/decor?category=Photobooth&limit=5`),
       fetchJson(`${apiUrl}/category`),
     ]);
 
@@ -2093,7 +2120,6 @@ export async function getServerSideProps(context) {
     const furniture = toList(furnitureData);
     const popular = toList(popularData);
     const spotlightList = Array.isArray(spotlightListData?.list) ? spotlightListData.list : [];
-    const photoboothDecor = toList(photoboothDecorData).slice(0, 5);
     const allCategories = Array.isArray(allCategoriesData?.list)
       ? allCategoriesData.list
       : Array.isArray(allCategoriesData)
@@ -2108,7 +2134,6 @@ export async function getServerSideProps(context) {
         furniture,
         popular,
         spotlightList,
-        photoboothDecor,
         allCategories,
       },
     };

--- a/pages/decor/index.js
+++ b/pages/decor/index.js
@@ -18,6 +18,7 @@ function Decor({
   user,
   spotlightList = [],
   photoboothDecor = [],
+  allCategories = [],
 }) {
   const [spotlightIndex, setSpotlightIndex] = useState(0);
   const spotlightRef = useRef(null);
@@ -33,18 +34,10 @@ function Decor({
     ReferenceId: "",
     message: "",
   });
-  const [categoryList, setCategoryList] = useState([
-    "Stage",
-    "Pathway",
-    "Entrance",
-    "Photobooth",
-    "Mandap",
-    "Nameboard",
-    "Furniture",
-    "Sound & Light",
-    "Entry Ideas",
-    "Props"
-  ]);
+  const TILE_CATEGORIES = ["Stage", "Pathway", "Entrance", "Photobooth", "Mandap", "Nameboard", "Furniture", "Sound & Light"];
+  const extraCategories = allCategories.filter(
+    (cat) => !TILE_CATEGORIES.some((tile) => tile.toLowerCase() === (cat.name || "").toLowerCase())
+  );
   const [showAllCategories, setShowAllCategories] = useState(false);
   const [bestSellerIndex, setBestSellerIndex] = useState([0, 1, 2, 3]);
   const [popularIndex, setPopularIndex] = useState([0, 1]);
@@ -728,7 +721,7 @@ function Decor({
           </div>
 
           <div className="grid grid-cols-2 gap-4 sm:gap-6 md:gap-8 justify-center w-full max-w-7xl">
-            {categoryList.slice(0, 8).map((item, index) => (
+            {TILE_CATEGORIES.map((item, index) => (
               <div
                 key={index}
                 className="group w-full h-[80px] sm:h-[100px] lg:h-[80px] relative rounded-md overflow-hidden opacity-100 shadow-md transform transition duration-300 hover:scale-[1.03]"
@@ -753,8 +746,8 @@ function Decor({
             ))}
           </div>
 
-          {/* View More/Less Button */}
-          {categoryList.length > 8 && (
+          {/* View More/Less Button — only shown when API returns categories beyond the 8 tiles */}
+          {extraCategories.length > 0 && (
             <div className="flex flex-col items-center w-full max-w-7xl mt-4 sm:mt-6 md:mt-8">
               <div className="flex justify-start md:justify-center w-full sm:px-0">
                 <div
@@ -776,19 +769,15 @@ function Decor({
                   </div>
                 </div>
               </div>
-              
-              {/* more Section – only categories not already shown in tiles */}
+
               {showAllCategories && (
                 <div className="w-full mt-6 bg-white rounded-md shadow-md p-4 md:p-6">
                   <div className="flex flex-wrap justify-center gap-4 md:gap-6">
-                    {categoryList.slice(8).map((item, index) => (
-                      <div
-                        key={index}
-                        className="text-center px-2"
-                      >
-                        <Link href={`/decor/view?category=${encodeURIComponent(item)}`} className="hover:underline">
-                          <span className="text-black text-xs sm:text-sm md:text-base font-medium uppercase tracking-wide whitespace-nowrap">
-                            {item.toUpperCase()}
+                    {extraCategories.map((cat) => (
+                      <div key={cat._id} className="text-center px-2">
+                        <Link href={`/decor/view?category=${encodeURIComponent(cat.name)}`} className="hover:underline">
+                          <span className="text-black text-xs sm:text-sm md:text-base font-medium tracking-wide whitespace-nowrap">
+                            {cat.name.charAt(0).toUpperCase() + cat.name.slice(1).toLowerCase()}
                           </span>
                         </Link>
                       </div>
@@ -2053,6 +2042,7 @@ export async function getServerSideProps(context) {
           popular: [],
           spotlightList: [],
           photoboothDecor: [],
+          allCategories: [],
         },
       };
     }
@@ -2083,6 +2073,7 @@ export async function getServerSideProps(context) {
       popularData,
       spotlightListData,
       photoboothDecorData,
+      allCategoriesData,
     ] = await Promise.all([
       fetchJson(`${apiUrl}/decor?label=bestSeller&category=Stage`),
       fetchJson(`${apiUrl}/decor?category=Entrance`),
@@ -2091,6 +2082,7 @@ export async function getServerSideProps(context) {
       fetchJson(`${apiUrl}/decor?label=popular`),
       fetchJson(`${apiUrl}/decor?spotlight=true&random=false`),
       fetchJson(`${apiUrl}/decor?category=Photobooth&limit=5`),
+      fetchJson(`${apiUrl}/category`),
     ]);
 
     const toList = (data) =>
@@ -2102,6 +2094,11 @@ export async function getServerSideProps(context) {
     const popular = toList(popularData);
     const spotlightList = Array.isArray(spotlightListData?.list) ? spotlightListData.list : [];
     const photoboothDecor = toList(photoboothDecorData).slice(0, 5);
+    const allCategories = Array.isArray(allCategoriesData?.list)
+      ? allCategoriesData.list
+      : Array.isArray(allCategoriesData)
+        ? allCategoriesData
+        : [];
 
     return {
       props: {
@@ -2112,6 +2109,7 @@ export async function getServerSideProps(context) {
         popular,
         spotlightList,
         photoboothDecor,
+        allCategories,
       },
     };
   } catch (error) {
@@ -2125,6 +2123,7 @@ export async function getServerSideProps(context) {
         popular: [],
         spotlightList: [],
         photoboothDecor: [],
+        allCategories: [],
       },
     };
   }

--- a/pages/decor/view/[decor_id].js
+++ b/pages/decor/view/[decor_id].js
@@ -2016,11 +2016,44 @@ export async function getServerSideProps(context) {
       };
     }
     
-    // Fetch similar decor filtered by the same category
-    const similarDecorResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/decor?similarDecorFor=${decor_id}&category=${encodeURIComponent(decor.category)}`
-    );
-    const similarDecor = await similarDecorResponse.json();
+    // Extract productVariation fields safely
+    const occasions = (decor.productVariation?.occassion || []).filter(Boolean);
+    const colors = (decor.productVariation?.colors || []).filter(Boolean);
+    const style = decor.productVariation?.style || "";
+
+    // Step 1 — strict: same category + occasion + color + style
+    const step1Params = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, limit: "20" });
+    if (occasions.length) step1Params.set("occassion", occasions.join("|"));
+    if (colors.length) step1Params.set("color", colors.join("|"));
+    if (style && style !== "Both") step1Params.set("style", style);
+
+    const step1Response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${step1Params}`);
+    const step1Data = await step1Response.json();
+    let combined = step1Data.list || [];
+
+    // Step 2 — relax to occasion-only if under 20 results
+    if (combined.length < 20 && occasions.length) {
+      const step2Params = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, occassion: occasions.join("|"), limit: "20" });
+      const step2Response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${step2Params}`);
+      const step2Data = await step2Response.json();
+      const seenIds = new Set(combined.map((i) => String(i._id)));
+      for (const item of step2Data.list || []) {
+        if (!seenIds.has(String(item._id))) {
+          combined.push(item);
+          seenIds.add(String(item._id));
+        }
+      }
+    }
+
+    // Fallback to category-only if no occasion set
+    if (!occasions.length) {
+      const fallbackParams = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, limit: "20" });
+      const fallbackResponse = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${fallbackParams}`);
+      const fallbackData = await fallbackResponse.json();
+      combined = fallbackData.list || [];
+    }
+
+    const similarDecorList = combined.filter((i) => String(i._id) !== String(decor_id)).slice(0, 20);
     
     const categoryResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_URL}/category`
@@ -2029,7 +2062,7 @@ export async function getServerSideProps(context) {
     const category = categoryList.find((i) => i.name === decor.category);
     return {
       props: {
-        similarDecor: similarDecor.list,
+        similarDecor: similarDecorList,
         decor,
         category,
         categoryList,

--- a/pages/decor/view/[decor_id].js
+++ b/pages/decor/view/[decor_id].js
@@ -2031,26 +2031,30 @@ export async function getServerSideProps(context) {
     const step1Data = await step1Response.json();
     let combined = step1Data.list || [];
 
-    // Step 2 — relax to occasion-only if under 20 results
-    if (combined.length < 20 && occasions.length) {
-      const step2Params = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, occassion: occasions.join("|"), limit: "20" });
-      const step2Response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${step2Params}`);
-      const step2Data = await step2Response.json();
+    const mergeInto = (list) => {
       const seenIds = new Set(combined.map((i) => String(i._id)));
-      for (const item of step2Data.list || []) {
+      for (const item of list) {
         if (!seenIds.has(String(item._id))) {
           combined.push(item);
           seenIds.add(String(item._id));
         }
       }
+    };
+
+    // Step 1.5 — drop color/style, keep occasion (only when Step 1 was strict and still < 20)
+    if (combined.length < 20 && occasions.length && (colors.length || (style && style !== "Both"))) {
+      const step15Params = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, occassion: occasions.join("|"), limit: "20" });
+      const step15Response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${step15Params}`);
+      const step15Data = await step15Response.json();
+      mergeInto(step15Data.list || []);
     }
 
-    // Fallback to category-only if no occasion set
-    if (!occasions.length) {
-      const fallbackParams = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, limit: "20" });
-      const fallbackResponse = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${fallbackParams}`);
-      const fallbackData = await fallbackResponse.json();
-      combined = fallbackData.list || [];
+    // Step 2 — category only (fires if still < 20 after steps 1 and 1.5)
+    if (combined.length < 20) {
+      const step2Params = new URLSearchParams({ similarDecorFor: decor_id, category: decor.category, limit: "20" });
+      const step2Response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${step2Params}`);
+      const step2Data = await step2Response.json();
+      mergeInto(step2Data.list || []);
     }
 
     const similarDecorList = combined.filter((i) => String(i._id) !== String(decor_id)).slice(0, 20);

--- a/pages/decor/view/[decor_id].js
+++ b/pages/decor/view/[decor_id].js
@@ -1509,10 +1509,10 @@ function DecorListing({
               <p className="md:hidden text-xl font-semibold mb-2 text-center">
                 {decor.name} ({decor?.productInfo.id})
               </p>
-              <div className={`relative pt-[56.25%] `}>
+              <div>
                 {displayImage && (
                   <div
-                    className="md:rounded-xl overflow-hidden shadow-lg decor-detail-image cursor-pointer absolute inset-0 w-full h-full"
+                    className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden shadow-lg decor-detail-image cursor-pointer"
                     onClick={() => {
                       const images = getAllImages();
                       const index = images.findIndex((img) => img === displayImage);
@@ -1522,16 +1522,18 @@ function DecorListing({
                     <Image
                       src={displayImage}
                       alt={decor.name}
-                      fill
-                      sizes="(max-width: 768px) 100vw, 60vw"
-                      className="object-contain transition-transform duration-300 hover:scale-105"
+                      width={0}
+                      height={0}
+                      sizes="100vw"
+                      style={{ width: "100%", height: "100%", maxHeight: "500px", objectFit: "contain" }}
+                      className="transition-transform duration-300 hover:scale-105"
                     />
                   </div>
                 )}
                 {displayVideo && (
                   <video
                     src={displayVideo}
-                    className="md:rounded-xl w-full h-full object-contain overflow-hidden absolute top-0"
+                    className="rounded-xl w-full object-contain overflow-hidden"
                     controls
                     autoPlay
                     muted
@@ -1794,8 +1796,8 @@ function DecorListing({
               <p className="text-2xl font-semibold text-center tracking-wide uppercase">
                 {decor.name} ({decor?.productInfo.id})
               </p>
-              <div 
-                className={`relative pt-[75%] mx-8 md:mx-16 cursor-pointer`}
+              <div
+                className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden mx-8 md:mx-16 cursor-pointer"
                 onClick={() => {
                   const currentImage = productVariant
                     ? decor.productVariants.find(
@@ -1803,7 +1805,6 @@ function DecorListing({
                       )?.image
                     : decor?.image;
                   const images = getAllImages();
-                  // If current image is from variant, use it; otherwise find index
                   const index = currentImage && images.includes(currentImage)
                     ? images.findIndex((img) => img === currentImage)
                     : 0;
@@ -1819,9 +1820,11 @@ function DecorListing({
                       : decor?.image
                   }
                   alt={decor.name}
-                  fill
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  className="object-contain md:rounded-xl transition-transform duration-300 hover:scale-105"
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  style={{ width: "100%", height: "100%", maxHeight: "500px", objectFit: "contain" }}
+                  className="transition-transform duration-300 hover:scale-105"
                 />
               </div>
             </div>

--- a/pages/decor/view/[decor_id].js
+++ b/pages/decor/view/[decor_id].js
@@ -1467,7 +1467,7 @@ function DecorListing({
               <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none hidden md:block" />
             </div>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-5 gap-8 py-8 md:pt-6 bg-[#F4F4F4]">
+          <div className="grid grid-cols-1 md:grid-cols-5 gap-8 py-8 md:pt-6 bg-[#F4F4F4] overflow-x-hidden max-w-full">
             <div className="hidden md:flex flex-col gap-6">
               <p className="text-xl font-medium text-center">DESCRIPTION</p>
               <div className="rounded-r-3xl bg-white shadow-md flex flex-col gap-2 p-4 px-6">
@@ -1493,7 +1493,7 @@ function DecorListing({
                 </ul>
               </div>
             </div>
-            <div className="flex flex-col gap-6 md:col-span-3">
+            <div className="flex flex-col gap-6 md:col-span-3 min-w-0 max-w-full overflow-hidden">
               <div className="hidden md:flex items-center gap-3">
                 <p className="text-2xl font-semibold tracking-wide uppercase">
                   {decor.category}
@@ -1509,11 +1509,11 @@ function DecorListing({
               <p className="md:hidden text-xl font-semibold mb-2 text-center">
                 {decor.name} ({decor?.productInfo.id})
               </p>
-              <div>
+              <div className="w-full overflow-hidden">
                 {displayImage && (
                   <div
                     className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden shadow-lg decor-detail-image cursor-pointer"
-                    style={{ width: "100%", display: "flex", justifyContent: "center", alignItems: "center" }}
+                    style={{ display: "flex", justifyContent: "center", alignItems: "center" }}
                     onClick={() => {
                       const images = getAllImages();
                       const index = images.findIndex((img) => img === displayImage);
@@ -1523,11 +1523,11 @@ function DecorListing({
                     <Image
                       src={displayImage}
                       alt={decor.name}
-                      width={0}
-                      height={0}
+                      width={800}
+                      height={600}
                       sizes="100vw"
                       style={{ maxWidth: "100%", height: "auto", maxHeight: "500px", objectFit: "contain" }}
-                      className="transition-transform duration-300 hover:scale-105"
+                      className="w-full h-auto object-contain transition-transform duration-300 hover:scale-105"
                     />
                   </div>
                 )}

--- a/pages/decor/view/[decor_id].js
+++ b/pages/decor/view/[decor_id].js
@@ -1513,6 +1513,7 @@ function DecorListing({
                 {displayImage && (
                   <div
                     className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden shadow-lg decor-detail-image cursor-pointer"
+                    style={{ width: "100%", display: "flex", justifyContent: "center", alignItems: "center" }}
                     onClick={() => {
                       const images = getAllImages();
                       const index = images.findIndex((img) => img === displayImage);
@@ -1525,7 +1526,7 @@ function DecorListing({
                       width={0}
                       height={0}
                       sizes="100vw"
-                      style={{ width: "100%", height: "100%", maxHeight: "500px", objectFit: "contain" }}
+                      style={{ maxWidth: "100%", height: "auto", maxHeight: "500px", objectFit: "contain" }}
                       className="transition-transform duration-300 hover:scale-105"
                     />
                   </div>

--- a/pages/decor/view/[decor_id].js
+++ b/pages/decor/view/[decor_id].js
@@ -1524,7 +1524,7 @@ function DecorListing({
                       alt={decor.name}
                       fill
                       sizes="(max-width: 768px) 100vw, 60vw"
-                      className="object-cover transition-transform duration-300 hover:scale-105"
+                      className="object-contain transition-transform duration-300 hover:scale-105"
                     />
                   </div>
                 )}
@@ -1821,7 +1821,7 @@ function DecorListing({
                   alt={decor.name}
                   fill
                   sizes="(max-width: 768px) 100vw, 50vw"
-                  className="object-cover md:rounded-xl transition-transform duration-300 hover:scale-105"
+                  className="object-contain md:rounded-xl transition-transform duration-300 hover:scale-105"
                 />
               </div>
             </div>

--- a/pages/decor/view/flooring.js
+++ b/pages/decor/view/flooring.js
@@ -1,0 +1,454 @@
+import Breadcrumbs from "@/components/Breadcrumbs";
+import DecorDisclaimer from "@/components/marquee/DecorDisclaimer";
+import CreateEventModal from "@/components/modal/CreateEventModal";
+import Toast from "@/components/other/Toast";
+import { Button, Checkbox, Dropdown, Label, Select, TextInput } from "flowbite-react";
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export default function FlooringPage({
+  flooringConfig,
+  categoryList,
+  userLoggedIn,
+  setOpenLoginModal,
+}) {
+  const flooringList = flooringConfig?.data?.flooringList || [];
+
+  const [eventList, setEventList] = useState([]);
+  const [showEventModal, setShowEventModal] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+  const [selectedFlooring, setSelectedFlooring] = useState(null);
+  const [dimensions, setDimensions] = useState({ length: "", breadth: "" });
+
+  const l = parseFloat(dimensions.length) || 0;
+  const b = parseFloat(dimensions.breadth) || 0;
+  const rate = selectedFlooring ? parseInt(selectedFlooring.price || 0) : 0;
+  const price = l > 0 && b > 0 && selectedFlooring ? Math.round(l * b * rate) : 0;
+  const canAdd = userLoggedIn && l > 0 && b > 0 && selectedFlooring != null;
+
+  const displayImage =
+    selectedFlooring?.image ||
+    flooringList[0]?.image ||
+    "/assets/images/carpet.webp";
+
+  const fetchEvents = () => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/event`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setEventList(data); })
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    if (userLoggedIn) fetchEvents();
+  }, [userLoggedIn]);
+
+  // Default to first flooring option on load
+  useEffect(() => {
+    if (flooringList.length > 0 && !selectedFlooring) {
+      setSelectedFlooring(flooringList[0]);
+    }
+  }, []);
+
+  const AddToEvent = ({ eventId, eventDayId }) => {
+    if (!canAdd) return;
+    fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/event/${eventId}/decor/${eventDayId}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify({
+          decor: "flooring",
+          category: "Furniture",
+          variant: selectedFlooring.title,
+          quantity: 1,
+          unit: "sq.ft",
+          platform: false,
+          flooring: "",
+          dimensions: { length: l, breadth: b, height: 0 },
+          price,
+          platformRate: 0,
+          flooringRate: 0,
+          decorPrice: price,
+          included: [],
+        }),
+      }
+    )
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.message === "success") {
+          fetchEvents();
+          const event = eventList.find((e) => e._id === eventId);
+          const day = event?.eventDays?.find((d) => d._id === eventDayId);
+          const msg = day?.name
+            ? `Added to ${event.name} - ${day.name}`
+            : `Added to ${event?.name || "your event"}`;
+          setToastMessage(msg);
+          setShowToast(true);
+        }
+      })
+      .catch(console.error);
+  };
+
+  function AddToEventButton() {
+    if (!userLoggedIn) {
+      return (
+        <Button
+          onClick={() => setOpenLoginModal(true)}
+          className="bg-black enabled:hover:bg-black md:bg-rose-900 md:enabled:hover:bg-rose-900 text-white text-center w-full shadow-lg"
+        >
+          ADD TO EVENT
+        </Button>
+      );
+    }
+
+    return (
+      <Dropdown
+        inline
+        arrowIcon={false}
+        dismissOnClick={false}
+        label={
+          <Button
+            className="bg-black enabled:hover:bg-black md:bg-rose-900 md:enabled:hover:bg-rose-900 text-white text-center w-full shadow-lg disabled:opacity-50"
+            disabled={!canAdd}
+          >
+            ADD TO EVENT
+          </Button>
+        }
+        className="border border-black rounded-lg bg-black"
+      >
+        <Dropdown.Item className="text-white bg-black">Event List</Dropdown.Item>
+        <div className="max-h-[400px] overflow-y-auto p-1">
+          {eventList?.map((item) => (
+            <div key={item._id}>
+              <Dropdown.Divider className="bg-black h-[1px] my-0" />
+              <Dropdown.Item className="bg-white flex flex-row gap-4" as="p">
+                <Label className="flex">{item.name}</Label>
+              </Dropdown.Item>
+              {item.eventDays?.map((rec) => (
+                <Dropdown.Item
+                  key={rec._id}
+                  className="bg-white flex flex-row gap-4"
+                  as={Label}
+                >
+                  <Checkbox
+                    checked={rec.decorItems?.some((i) => i.decor === "flooring")}
+                    className={item.status?.finalized ? "sr-only" : ""}
+                    disabled={item.status?.finalized}
+                    onChange={(e) => {
+                      if (e.target.checked && !item.status?.finalized) {
+                        AddToEvent({ eventId: item._id, eventDayId: rec._id });
+                      }
+                    }}
+                  />
+                  {rec.name}
+                </Dropdown.Item>
+              ))}
+            </div>
+          ))}
+        </div>
+        <Dropdown.Divider className="bg-black h-[1px] my-0" />
+        <Dropdown.Item
+          onClick={() => setShowEventModal(true)}
+          className="bg-white text-cyan-600"
+        >
+          + Create New Event
+        </Dropdown.Item>
+      </Dropdown>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Flooring | Wedding Furniture Decor | Wedsy</title>
+        <meta
+          name="description"
+          content="Choose from our premium flooring options for your wedding setup. Carpet, vinyl, printed flex and more. Custom dimensions at competitive prices. Book with Wedsy."
+        />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href="https://www.wedsy.in/decor/view/flooring" />
+        <meta property="og:title" content="Flooring | Wedding Furniture Decor | Wedsy" />
+        <meta
+          property="og:description"
+          content="Premium flooring options for wedding setups. Custom dimensions at competitive prices."
+        />
+        {displayImage && <meta property="og:image" content={displayImage} />}
+        <meta property="og:url" content="https://www.wedsy.in/decor/view/flooring" />
+        <meta property="og:type" content="product" />
+        <meta property="og:site_name" content="Wedsy" />
+      </Head>
+
+      <CreateEventModal
+        showEventModal={showEventModal}
+        setShowEventModal={setShowEventModal}
+        userLoggedIn={userLoggedIn}
+        setOpenLoginModal={setOpenLoginModal}
+        fetchEvents={fetchEvents}
+      />
+      <Toast
+        message={toastMessage}
+        show={showToast}
+        onClose={() => setShowToast(false)}
+      />
+      <DecorDisclaimer />
+
+      <div className="max-w-screen-xl mx-auto px-4 md:px-8 py-2">
+        <Breadcrumbs
+          items={[
+            { name: "Home", href: "/" },
+            { name: "Decor", href: "/decor" },
+            { name: "Furniture", href: "/decor/view?category=Furniture" },
+            { name: "Flooring" },
+          ]}
+        />
+      </div>
+
+      {/* Category filter pills */}
+      <div className="w-full bg-white border-b border-gray-200 sticky top-0 z-30">
+        <div className="relative">
+          <div className="overflow-x-auto scrollbar-hide px-4 py-3">
+            <div className="flex flex-row gap-3 flex-nowrap min-w-max">
+              {categoryList?.map((item) => (
+                <Link
+                  href={`/decor/view?category=${encodeURIComponent(item.name)}`}
+                  key={item._id}
+                  className={`whitespace-nowrap rounded-full font-medium py-2 px-5 text-sm transition-all duration-200 flex-shrink-0 ${
+                    item.name === "Furniture"
+                      ? "bg-[#840032] text-white shadow-md"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 hover:shadow-sm"
+                  }`}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none hidden md:block" />
+        </div>
+      </div>
+
+      {/* Layout B — single image, 4-column grid */}
+      <div className="relative grid grid-cols-1 md:grid-cols-4 gap-8 py-8 decor-bg-image border-b-2 border-b-white">
+        {/* Left col: About */}
+        <div className="hidden md:flex flex-col gap-6">
+          <div className="rounded-r-3xl bg-white shadow-md flex flex-col gap-2 p-8 my-4">
+            <p className="text-lg font-medium">About</p>
+            <ul className="list-disc pl-8 flex flex-col gap-2 text-sm font-normal">
+              <li>Choose from multiple premium flooring types</li>
+              <li>Pricing calculated as Length × Breadth × Rate</li>
+              {flooringList.map((f) => (
+                <li key={f.title}>
+                  {f.title}: ₹{parseInt(f.price || 0)}/sq.ft
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* Center col: Image + flooring selector */}
+        <div className="flex flex-col gap-6 md:col-span-2 md:px-8 md:mx-6 md:border-x-4 md:border-x-white">
+          <p className="text-2xl font-semibold text-center tracking-wide uppercase">Flooring</p>
+
+          <div className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden mx-8 md:mx-16">
+            <Image
+              src={displayImage}
+              alt={selectedFlooring?.title || "Flooring"}
+              width={0}
+              height={0}
+              sizes="100vw"
+              style={{ width: "100%", height: "100%", maxHeight: "500px", objectFit: "contain" }}
+            />
+          </div>
+
+          {/* Flooring type thumbnails */}
+          {flooringList.length > 1 && (
+            <div className="flex flex-row gap-3 items-center justify-center flex-wrap px-4">
+              {flooringList.map((f) => (
+                <button
+                  key={f.title}
+                  onClick={() => setSelectedFlooring(f)}
+                  className={`relative h-16 w-16 rounded-lg overflow-hidden border-2 transition-all ${
+                    selectedFlooring?.title === f.title
+                      ? "border-rose-900 shadow-md"
+                      : "border-gray-200 hover:border-gray-400"
+                  }`}
+                  title={f.title}
+                >
+                  {f.image ? (
+                    <img
+                      src={f.image}
+                      alt={f.title}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-gray-100 flex items-center justify-center">
+                      <span className="text-xs text-gray-500 text-center px-1">{f.title}</span>
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Mobile: inputs + button */}
+          <div className="grid grid-cols-2 items-center md:hidden gap-3 px-8 mt-2">
+            <p className="col-span-2 text-sm font-medium">Flooring Type</p>
+            <div className="col-span-2">
+              <Select
+                value={selectedFlooring?.title || ""}
+                onChange={(e) => {
+                  const found = flooringList.find((f) => f.title === e.target.value);
+                  setSelectedFlooring(found || null);
+                }}
+              >
+                {flooringList.map((f) => (
+                  <option key={f.title} value={f.title}>
+                    {f.title} — ₹{parseInt(f.price || 0)}/sq.ft
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <p className="text-sm font-medium">Length (ft)</p>
+            <TextInput
+              type="number"
+              placeholder="0"
+              value={dimensions.length}
+              min={0}
+              onChange={(e) => setDimensions({ ...dimensions, length: e.target.value })}
+            />
+            <p className="text-sm font-medium">Breadth (ft)</p>
+            <TextInput
+              type="number"
+              placeholder="0"
+              value={dimensions.breadth}
+              min={0}
+              onChange={(e) => setDimensions({ ...dimensions, breadth: e.target.value })}
+            />
+            <div className="col-span-2 flex flex-col mt-1">
+              <AddToEventButton />
+            </div>
+          </div>
+
+          {/* Mobile: about */}
+          <div className="flex md:hidden flex-col gap-2 p-8">
+            <p className="text-lg font-medium">About</p>
+            <ul className="list-disc pl-8 flex flex-col gap-2 text-sm font-normal">
+              <li>Choose from multiple premium flooring types</li>
+              <li>Price = Length × Breadth × Rate per sq.ft</li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Mobile: fixed bottom bar */}
+        <div className="fixed z-50 bottom-0 w-full grid md:hidden grid-cols-2 gap-4 bg-white p-4 border-t border-gray-200">
+          <p className="text-xl font-semibold text-rose-900">
+            {selectedFlooring ? `₹ ${rate}/sq.ft` : "Select type"}
+          </p>
+          <p className="text-xl font-semibold text-right text-gray-600">
+            {price > 0 ? `Total ₹ ${price}` : "Enter dimensions"}
+          </p>
+        </div>
+
+        {/* Right col: Price panel */}
+        <div className="hidden md:flex flex-col gap-6">
+          <div className="rounded-l-3xl bg-white shadow-md flex flex-col gap-4 p-8 my-4">
+            <div className="border-b-2 border-gray-500 pb-2">
+              <p className="text-xl font-semibold">
+                {selectedFlooring ? (
+                  <>₹ {rate} <span className="text-sm font-normal">per sq.ft</span></>
+                ) : (
+                  <span className="text-base font-normal text-gray-500">Select flooring type</span>
+                )}
+              </p>
+            </div>
+
+            {/* Flooring type select */}
+            <div className="border-b-2 border-gray-500 pb-4 flex flex-col gap-2">
+              <p className="text-sm">Flooring Type</p>
+              <Select
+                value={selectedFlooring?.title || ""}
+                onChange={(e) => {
+                  const found = flooringList.find((f) => f.title === e.target.value);
+                  setSelectedFlooring(found || null);
+                }}
+              >
+                {flooringList.map((f) => (
+                  <option key={f.title} value={f.title}>
+                    {f.title} — ₹{parseInt(f.price || 0)}/sq.ft
+                  </option>
+                ))}
+              </Select>
+            </div>
+
+            {/* Dimension inputs */}
+            <div className="border-b-2 border-gray-500 pb-4 flex flex-col gap-3">
+              <p className="text-sm font-medium">Dimensions (ft)</p>
+              <div className="grid grid-cols-2 items-center gap-y-3">
+                <p className="text-sm">Length</p>
+                <TextInput
+                  type="number"
+                  placeholder="0"
+                  value={dimensions.length}
+                  min={0}
+                  sizing="sm"
+                  onChange={(e) => setDimensions({ ...dimensions, length: e.target.value })}
+                />
+                <p className="text-sm">Breadth</p>
+                <TextInput
+                  type="number"
+                  placeholder="0"
+                  value={dimensions.breadth}
+                  min={0}
+                  sizing="sm"
+                  onChange={(e) => setDimensions({ ...dimensions, breadth: e.target.value })}
+                />
+              </div>
+            </div>
+
+            {price > 0 && (
+              <div className="border-b-2 border-gray-500 pb-2 grid grid-cols-2 items-center gap-y-4">
+                <p className="text-sm">Total Price</p>
+                <p className="text-xl font-semibold">₹ {price}</p>
+              </div>
+            )}
+
+            <AddToEventButton />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export async function getServerSideProps() {
+  try {
+    const [flooringRes, categoryRes] = await Promise.all([
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/config?code=flooring`),
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/category`),
+    ]);
+    const [flooringConfig, categoryList] = await Promise.all([
+      flooringRes.json(),
+      categoryRes.json(),
+    ]);
+    return {
+      props: {
+        flooringConfig: flooringConfig || {},
+        categoryList: Array.isArray(categoryList) ? categoryList : [],
+      },
+    };
+  } catch {
+    return { props: { flooringConfig: {}, categoryList: [] } };
+  }
+}

--- a/pages/decor/view/flooring.js
+++ b/pages/decor/view/flooring.js
@@ -259,7 +259,7 @@ export default function FlooringPage({
 
         {/* Center col: Image + flooring selector */}
         <div className="flex flex-col gap-6 md:col-span-2 md:px-8 md:mx-6 md:border-x-4 md:border-x-white">
-          <p className="text-2xl font-semibold text-center tracking-wide uppercase">Flooring</p>
+          <p className="text-2xl font-semibold text-center tracking-wide uppercase">Flooring <span className="text-base font-normal text-gray-400">(fp02)</span></p>
 
           <div className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden mx-8 md:mx-16">
             <Image
@@ -279,7 +279,7 @@ export default function FlooringPage({
                 <button
                   key={f.title}
                   onClick={() => setSelectedFlooring(f)}
-                  className={`relative h-16 w-16 rounded-lg overflow-hidden border-2 transition-all ${
+                  className={`relative h-24 w-24 rounded-lg overflow-hidden border-2 transition-all ${
                     selectedFlooring?.title === f.title
                       ? "border-rose-900 shadow-md"
                       : "border-gray-200 hover:border-gray-400"
@@ -290,7 +290,7 @@ export default function FlooringPage({
                     <img
                       src={f.image}
                       alt={f.title}
-                      className="w-full h-full object-cover"
+                      className="w-full h-full object-contain"
                     />
                   ) : (
                     <div className="w-full h-full bg-gray-100 flex items-center justify-center">

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -1,7 +1,6 @@
 import Breadcrumbs from "@/components/Breadcrumbs";
 import DecorCard from "@/components/cards/DecorCard";
 import DecorDisclaimer from "@/components/marquee/DecorDisclaimer";
-import { SpecificCategorySkeleton } from "@/components/skeletons/wedding-store/specific-category";
 import { trimTitle, trimDescription, OG_IMAGES } from "@/utils/seo";
 import { Dropdown } from "flowbite-react";
 import Head from "next/head";
@@ -1222,7 +1221,25 @@ function DecorListing({
           </h1>
 
           {loading ? (
-            <SpecificCategorySkeleton />
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex flex-col gap-2">
+                  <div className={`relative overflow-hidden rounded-2xl bg-gray-200 ${
+                    i % 4 === 0 || i % 4 === 3 ? 'h-40' : 'h-52'
+                  }`}>
+                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-shimmer" />
+                  </div>
+                  <div className="hidden md:flex gap-2 px-1">
+                    <div className="relative flex-1 overflow-hidden h-3 rounded bg-gray-200">
+                      <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-shimmer" />
+                    </div>
+                    <div className="relative overflow-hidden h-3 w-16 rounded bg-gray-200">
+                      <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-shimmer" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
           ) : list.length > 0 ? (
             <>
               {/* Mobile Grid */}

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -84,20 +84,27 @@ function DecorListing({
   const filterButtonRef = useRef(null);
   const filterDropdownContentRef = useRef(null);
 
-  const allOccasions = [
-    "Reception",
-    "Engagement",
-    "Sangeet",
-    "Wedding",
-    "Haldi",
-    "Mehendi",
-    "Muhurtham",
-  ];
+  const [allOccasions, setAllOccasions] = useState([]);
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/attribute`)
+      .then((r) => r.json())
+      .then((attrs) => {
+        const attr = attrs.find((a) => a.name === "Occasion");
+        if (attr?.list?.length) {
+          setAllOccasions(
+            attr.list.map((o) => o.charAt(0).toUpperCase() + o.slice(1).toLowerCase())
+          );
+        }
+      })
+      .catch(() => {});
+  }, []);
+
   const isStageOrBackdrop =
     (filters.category || "").toLowerCase() === "stage" ||
     (filters.category || "").toLowerCase() === "backdrop";
   const occasionList = isStageOrBackdrop
-    ? allOccasions.filter((o) => o !== "Muhurtham")
+    ? allOccasions.filter((o) => o.toLowerCase() !== "muhurtham")
     : allOccasions;
 
   const coloursList = [
@@ -232,12 +239,8 @@ function DecorListing({
       });
 
       if (filters.category) params.append("category", filters.category);
-      if (
-        filters.sort &&
-        filters.sort !== "Sort" &&
-        filters.sort !== "New-Arrivals"
-      ) {
-        params.append("sort", filters.sort);
+      if (filters.sort && filters.sort !== "Sort") {
+        params.append("sort", filters.sort === "New-Arrivals" ? "Newest-First" : filters.sort);
       }
       // For categories with full filters only: occasion, colours, type, size
       if (hasFullFilters) {
@@ -322,12 +325,6 @@ function DecorListing({
           });
         }
         
-        if (filters.sort === "New-Arrivals") {
-          sortedList = [...sortedList].sort(
-            (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
-          );
-        }
-
         setList(sortedList);
         setTotalPages(data.totalPages || 1);
       } catch (error) {

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -487,7 +487,7 @@ function DecorListing({
     productTypes: [{ name: "sq.ft", sellingPrice: parseInt(platformConfig?.data?.price || 0) }],
     category: "Furniture",
     unit: "sq.ft",
-    productInfo: {},
+    productInfo: { id: "fp01" },
   };
 
   const _flooringList = flooringConfig?.data?.flooringList || [];
@@ -500,7 +500,7 @@ function DecorListing({
       : [{ name: "sq.ft", sellingPrice: 0 }],
     category: "Furniture",
     unit: "sq.ft",
-    productInfo: {},
+    productInfo: { id: "fp02" },
   };
 
   const displayList = isFurnitureCategory

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -87,7 +87,7 @@ function DecorListing({
   const [allOccasions, setAllOccasions] = useState([]);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/attribute`)
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/attribute/public`)
       .then((r) => r.json())
       .then((attrs) => {
         const attr = attrs.find((a) => a.name === "Occasion");

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -43,6 +43,8 @@ function DecorListing({
   initialData,
   categoryList,
   totalPages: initialTotalPages,
+  platformConfig,
+  flooringConfig,
 }) {
   const router = useRouter();
   const { category, page: queryPage } = router.query;
@@ -475,6 +477,35 @@ function DecorListing({
   };
 
   const dynamicHeading = filters.category ? `${filters.category}` : "All Decor";
+
+  const isFurnitureCategory = (filters.category || "").toLowerCase() === "furniture";
+
+  const platformCard = {
+    _id: "platform",
+    thumbnail: platformConfig?.data?.image || "/assets/images/platform.webp",
+    name: "Platform",
+    productTypes: [{ name: "sq.ft", sellingPrice: parseInt(platformConfig?.data?.price || 0) }],
+    category: "Furniture",
+    unit: "sq.ft",
+    productInfo: {},
+  };
+
+  const _flooringList = flooringConfig?.data?.flooringList || [];
+  const flooringCard = {
+    _id: "flooring",
+    thumbnail: _flooringList[0]?.image || "/assets/images/carpet.webp",
+    name: "Flooring",
+    productTypes: _flooringList.length
+      ? _flooringList.map((f) => ({ name: f.title, sellingPrice: parseInt(f.price || 0) }))
+      : [{ name: "sq.ft", sellingPrice: 0 }],
+    category: "Furniture",
+    unit: "sq.ft",
+    productInfo: {},
+  };
+
+  const displayList = isFurnitureCategory
+    ? [platformCard, flooringCard, ...list]
+    : list;
 
 
   const renderPaginationNumbers = () => {
@@ -1240,7 +1271,7 @@ function DecorListing({
                 </div>
               ))}
             </div>
-          ) : list.length > 0 ? (
+          ) : displayList.length > 0 ? (
             <>
               {/* Mobile Grid */}
               <div className="block md:hidden">
@@ -1249,7 +1280,7 @@ function DecorListing({
                   className="my-masonry-grid"
                   columnClassName="my-masonry-grid_column"
                 >
-                  {list.map((item, index) => (
+                  {displayList.map((item, index) => (
                     <div key={item._id}>
                       <DecorCard
                         decor={item}
@@ -1270,7 +1301,7 @@ function DecorListing({
                   className="my-masonry-grid"
                   columnClassName="my-masonry-grid_column"
                 >
-                  {list.map((item) => (
+                  {displayList.map((item) => (
                     <div key={item._id}>
                       <DecorCard decor={item} />
                     </div>
@@ -1381,25 +1412,38 @@ export async function getServerSideProps(context) {
     });
     const categoryToFetch = query.category || "Stage";
     params.append("category", categoryToFetch);
-    const decorResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/decor?${params.toString()}`
-    );
-    const decorData = await decorResponse.json();
-    const categoryResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/category`
-    );
-    const categoryList = await categoryResponse.json();
+    const isFurniture = categoryToFetch.toLowerCase() === "furniture";
+
+    const fetches = [
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/decor?${params.toString()}`),
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/category`),
+    ];
+    if (isFurniture) {
+      fetches.push(fetch(`${process.env.NEXT_PUBLIC_API_URL}/config?code=platform`));
+      fetches.push(fetch(`${process.env.NEXT_PUBLIC_API_URL}/config?code=flooring`));
+    }
+
+    const responses = await Promise.all(fetches);
+    const [decorData, categoryList] = await Promise.all([
+      responses[0].json(),
+      responses[1].json(),
+    ]);
+    const platformConfig = isFurniture ? await responses[2].json() : {};
+    const flooringConfig = isFurniture ? await responses[3].json() : {};
+
     return {
       props: {
         initialData: decorData.list || [],
         categoryList: categoryList || [],
         totalPages: decorData.totalPages || 1,
+        platformConfig: platformConfig || {},
+        flooringConfig: flooringConfig || {},
       },
     };
   } catch (error) {
     console.error("Error fetching initial data:", error);
     return {
-      props: { initialData: [], categoryList: [], totalPages: 1 },
+      props: { initialData: [], categoryList: [], totalPages: 1, platformConfig: {}, flooringConfig: {} },
     };
   }
 }

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -1231,7 +1231,7 @@ function DecorListing({
               {/* Mobile Grid */}
               <div className="block md:hidden">
                 <Masonry
-                  breakpointCols={2}
+                  breakpointCols={{ default: 4, 1280: 4, 1024: 3, 768: 2, 500: 2 }}
                   className="my-masonry-grid"
                   columnClassName="my-masonry-grid_column"
                 >
@@ -1252,7 +1252,7 @@ function DecorListing({
 
               <div className="hidden md:block">
                 <Masonry
-                  breakpointCols={{ default: 3, 1100: 3, 700: 2, 500: 2 }}
+                  breakpointCols={{ default: 4, 1280: 4, 1024: 3, 768: 2, 500: 2 }}
                   className="my-masonry-grid"
                   columnClassName="my-masonry-grid_column"
                 >

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -480,22 +480,6 @@ function DecorListing({
 
   const dynamicHeading = filters.category ? `${filters.category}` : "All Decor";
 
-  const gridClasses = [
-    "md:col-span-2 md:row-span-2",
-    "md:col-span-4 md:row-span-2 md:col-start-3",
-    "md:col-span-2 md:row-span-2 md:col-start-7",
-    "md:col-span-2 md:row-span-2 md:row-start-3",
-    "md:col-span-3 md:row-span-2 md:col-start-3 md:row-start-3",
-    "md:col-span-3 md:row-span-2 md:col-start-6 md:row-start-3",
-    "md:col-span-4 md:row-span-3 md:row-start-5",
-    "md:col-span-4 md:row-span-3 md:col-start-5 md:row-start-5",
-    "md:col-span-4 md:row-span-2 md:row-start-8",
-    "md:col-span-4 md:row-span-2 md:col-start-5 md:row-start-8",
-    "md:col-span-3 md:row-span-2 md:row-start-10",
-    "md:col-span-4 md:row-span-2 md:col-start-4 md:row-start-10",
-    "md:col-span-4 md:row-span-2 md:row-start-12",
-    "md:col-span-3 md:row-span-2 md:col-start-5 md:row-start-12",
-  ];
 
   const renderPaginationNumbers = () => {
     const numbers = [];
@@ -1266,18 +1250,18 @@ function DecorListing({
                 </Masonry>
               </div>
 
-              <div className="hidden md:grid grid-cols-2 sm:grid-cols-3 md:grid-cols-8 md:grid-rows-13 gap-2 md:gap-4 min-h-[1600px]">
-                {list.map((item, index) => (
-                  <div
-                    key={item._id}
-                    className={
-                      gridClasses[index] ||
-                      "col-span-1 sm:col-span-1 md:col-span-3 md:row-span-2"
-                    }
-                  >
-                    <DecorCard decor={item} />
-                  </div>
-                ))}
+              <div className="hidden md:block">
+                <Masonry
+                  breakpointCols={{ default: 3, 1100: 3, 700: 2, 500: 2 }}
+                  className="my-masonry-grid"
+                  columnClassName="my-masonry-grid_column"
+                >
+                  {list.map((item) => (
+                    <div key={item._id}>
+                      <DecorCard decor={item} />
+                    </div>
+                  ))}
+                </Masonry>
               </div>
 
               <div className="flex flex-col items-center mt-12 gap-4" role="navigation" aria-label="Decor listing pagination">

--- a/pages/decor/view/index.js
+++ b/pages/decor/view/index.js
@@ -226,7 +226,7 @@ function DecorListing({
       setLoading(true);
       const params = new URLSearchParams({
         page: currentPage.toString(),
-        limit: "14",
+        limit: "32",
         displayVisible: "true",
         displayAvailable: "true",
       });
@@ -1361,7 +1361,7 @@ export async function getServerSideProps(context) {
     const currentPage = query.page || "1";
     const params = new URLSearchParams({
       page: currentPage,
-      limit: "14",
+      limit: "32",
       displayVisible: "true",
       displayAvailable: "true",
     });

--- a/pages/decor/view/platform.js
+++ b/pages/decor/view/platform.js
@@ -1,0 +1,389 @@
+import Breadcrumbs from "@/components/Breadcrumbs";
+import DecorDisclaimer from "@/components/marquee/DecorDisclaimer";
+import CreateEventModal from "@/components/modal/CreateEventModal";
+import Toast from "@/components/other/Toast";
+import { Button, Checkbox, Dropdown, Label, TextInput } from "flowbite-react";
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export default function PlatformPage({
+  platformConfig,
+  categoryList,
+  userLoggedIn,
+  setOpenLoginModal,
+}) {
+  const rate = parseInt(platformConfig?.data?.price || 0);
+  const image = platformConfig?.data?.image || "/assets/images/platform.webp";
+
+  const [eventList, setEventList] = useState([]);
+  const [showEventModal, setShowEventModal] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+  const [dimensions, setDimensions] = useState({ length: "", breadth: "", height: "" });
+
+  const l = parseFloat(dimensions.length) || 0;
+  const b = parseFloat(dimensions.breadth) || 0;
+  const h = parseFloat(dimensions.height) || 0;
+  const price = l > 0 && b > 0 && h > 0 ? Math.round(l * b * rate) : 0;
+  const canAdd = userLoggedIn && l > 0 && b > 0 && h > 0;
+
+  const fetchEvents = () => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/event`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setEventList(data); })
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    if (userLoggedIn) fetchEvents();
+  }, [userLoggedIn]);
+
+  const AddToEvent = ({ eventId, eventDayId }) => {
+    if (!canAdd) return;
+    fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/event/${eventId}/decor/${eventDayId}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify({
+          decor: "platform",
+          category: "Furniture",
+          variant: "",
+          quantity: 1,
+          unit: "sq.ft",
+          platform: false,
+          flooring: "",
+          dimensions: { length: l, breadth: b, height: h },
+          price,
+          platformRate: 0,
+          flooringRate: 0,
+          decorPrice: price,
+          included: [],
+        }),
+      }
+    )
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.message === "success") {
+          fetchEvents();
+          const event = eventList.find((e) => e._id === eventId);
+          const day = event?.eventDays?.find((d) => d._id === eventDayId);
+          const msg = day?.name
+            ? `Added to ${event.name} - ${day.name}`
+            : `Added to ${event?.name || "your event"}`;
+          setToastMessage(msg);
+          setShowToast(true);
+        }
+      })
+      .catch(console.error);
+  };
+
+  function AddToEventButton() {
+    if (!userLoggedIn) {
+      return (
+        <Button
+          onClick={() => setOpenLoginModal(true)}
+          className="bg-black enabled:hover:bg-black md:bg-rose-900 md:enabled:hover:bg-rose-900 text-white text-center w-full shadow-lg"
+        >
+          ADD TO EVENT
+        </Button>
+      );
+    }
+
+    return (
+      <Dropdown
+        inline
+        arrowIcon={false}
+        dismissOnClick={false}
+        label={
+          <Button
+            className="bg-black enabled:hover:bg-black md:bg-rose-900 md:enabled:hover:bg-rose-900 text-white text-center w-full shadow-lg disabled:opacity-50"
+            disabled={!canAdd}
+          >
+            ADD TO EVENT
+          </Button>
+        }
+        className="border border-black rounded-lg bg-black"
+      >
+        <Dropdown.Item className="text-white bg-black">Event List</Dropdown.Item>
+        <div className="max-h-[400px] overflow-y-auto p-1">
+          {eventList?.map((item) => (
+            <div key={item._id}>
+              <Dropdown.Divider className="bg-black h-[1px] my-0" />
+              <Dropdown.Item className="bg-white flex flex-row gap-4" as="p">
+                <Label className="flex">{item.name}</Label>
+              </Dropdown.Item>
+              {item.eventDays?.map((rec) => (
+                <Dropdown.Item
+                  key={rec._id}
+                  className="bg-white flex flex-row gap-4"
+                  as={Label}
+                >
+                  <Checkbox
+                    checked={rec.decorItems?.some((i) => i.decor === "platform")}
+                    className={item.status?.finalized ? "sr-only" : ""}
+                    disabled={item.status?.finalized}
+                    onChange={(e) => {
+                      if (e.target.checked && !item.status?.finalized) {
+                        AddToEvent({ eventId: item._id, eventDayId: rec._id });
+                      }
+                    }}
+                  />
+                  {rec.name}
+                </Dropdown.Item>
+              ))}
+            </div>
+          ))}
+        </div>
+        <Dropdown.Divider className="bg-black h-[1px] my-0" />
+        <Dropdown.Item
+          onClick={() => setShowEventModal(true)}
+          className="bg-white text-cyan-600"
+        >
+          + Create New Event
+        </Dropdown.Item>
+      </Dropdown>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Platform | Wedding Furniture Decor | Wedsy</title>
+        <meta
+          name="description"
+          content="Add a platform to elevate your wedding decor setup for better visibility. Custom dimensions, competitive pricing. Book now with Wedsy."
+        />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href="https://www.wedsy.in/decor/view/platform" />
+        <meta property="og:title" content="Platform | Wedding Furniture Decor | Wedsy" />
+        <meta
+          property="og:description"
+          content="Add a platform to elevate your wedding decor setup. Custom dimensions at competitive prices."
+        />
+        {image && <meta property="og:image" content={image} />}
+        <meta property="og:url" content="https://www.wedsy.in/decor/view/platform" />
+        <meta property="og:type" content="product" />
+        <meta property="og:site_name" content="Wedsy" />
+      </Head>
+
+      <CreateEventModal
+        showEventModal={showEventModal}
+        setShowEventModal={setShowEventModal}
+        userLoggedIn={userLoggedIn}
+        setOpenLoginModal={setOpenLoginModal}
+        fetchEvents={fetchEvents}
+      />
+      <Toast
+        message={toastMessage}
+        show={showToast}
+        onClose={() => setShowToast(false)}
+      />
+      <DecorDisclaimer />
+
+      <div className="max-w-screen-xl mx-auto px-4 md:px-8 py-2">
+        <Breadcrumbs
+          items={[
+            { name: "Home", href: "/" },
+            { name: "Decor", href: "/decor" },
+            { name: "Furniture", href: "/decor/view?category=Furniture" },
+            { name: "Platform" },
+          ]}
+        />
+      </div>
+
+      {/* Category filter pills */}
+      <div className="w-full bg-white border-b border-gray-200 sticky top-0 z-30">
+        <div className="relative">
+          <div className="overflow-x-auto scrollbar-hide px-4 py-3">
+            <div className="flex flex-row gap-3 flex-nowrap min-w-max">
+              {categoryList?.map((item) => (
+                <Link
+                  href={`/decor/view?category=${encodeURIComponent(item.name)}`}
+                  key={item._id}
+                  className={`whitespace-nowrap rounded-full font-medium py-2 px-5 text-sm transition-all duration-200 flex-shrink-0 ${
+                    item.name === "Furniture"
+                      ? "bg-[#840032] text-white shadow-md"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 hover:shadow-sm"
+                  }`}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none hidden md:block" />
+        </div>
+      </div>
+
+      {/* Layout B — single image, 4-column grid */}
+      <div className="relative grid grid-cols-1 md:grid-cols-4 gap-8 py-8 decor-bg-image border-b-2 border-b-white">
+        {/* Left col: About */}
+        <div className="hidden md:flex flex-col gap-6">
+          <div className="rounded-r-3xl bg-white shadow-md flex flex-col gap-2 p-8 my-4">
+            <p className="text-lg font-medium">About</p>
+            <ul className="list-disc pl-8 flex flex-col gap-2 text-sm font-normal">
+              <li>Platforms elevate your decor for better visibility and presentation</li>
+              <li>Rate: ₹{rate} per sq.ft</li>
+              <li>Price is calculated as Length × Breadth × Rate</li>
+              <li>Enter your dimensions on the right to get the total cost</li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Center col: Image */}
+        <div className="flex flex-col gap-6 md:col-span-2 md:px-8 md:mx-6 md:border-x-4 md:border-x-white">
+          <p className="text-2xl font-semibold text-center tracking-wide uppercase">Platform</p>
+          <div className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden mx-8 md:mx-16">
+            <Image
+              src={image}
+              alt="Platform"
+              width={0}
+              height={0}
+              sizes="100vw"
+              style={{ width: "100%", height: "100%", maxHeight: "500px", objectFit: "contain" }}
+            />
+          </div>
+
+          {/* Mobile: dimension inputs */}
+          <div className="grid grid-cols-2 items-center md:hidden gap-3 px-8 mt-2">
+            <p className="text-sm font-medium">Length (ft)</p>
+            <TextInput
+              type="number"
+              placeholder="0"
+              value={dimensions.length}
+              min={0}
+              onChange={(e) => setDimensions({ ...dimensions, length: e.target.value })}
+            />
+            <p className="text-sm font-medium">Breadth (ft)</p>
+            <TextInput
+              type="number"
+              placeholder="0"
+              value={dimensions.breadth}
+              min={0}
+              onChange={(e) => setDimensions({ ...dimensions, breadth: e.target.value })}
+            />
+            <p className="text-sm font-medium">Height (ft)</p>
+            <TextInput
+              type="number"
+              placeholder="0"
+              value={dimensions.height}
+              min={0}
+              onChange={(e) => setDimensions({ ...dimensions, height: e.target.value })}
+            />
+            <div className="col-span-2 flex flex-col mt-1">
+              <AddToEventButton />
+            </div>
+          </div>
+
+          {/* Mobile: about */}
+          <div className="flex md:hidden flex-col gap-2 p-8">
+            <p className="text-lg font-medium">About</p>
+            <ul className="list-disc pl-8 flex flex-col gap-2 text-sm font-normal">
+              <li>Platforms elevate your decor for better visibility</li>
+              <li>Rate: ₹{rate} per sq.ft</li>
+              <li>Price = Length × Breadth × Rate</li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Mobile: fixed bottom bar */}
+        <div className="fixed z-50 bottom-0 w-full grid md:hidden grid-cols-2 gap-4 bg-white p-4 border-t border-gray-200">
+          <p className="text-xl font-semibold text-rose-900">
+            {price > 0 ? `₹ ${price}` : `₹ ${rate}/sq.ft`}
+          </p>
+          <p className="text-xl font-semibold text-right text-gray-600">
+            {price > 0 ? `Total ₹ ${price}` : "Enter dimensions"}
+          </p>
+        </div>
+
+        {/* Right col: Price panel */}
+        <div className="hidden md:flex flex-col gap-6">
+          <div className="rounded-l-3xl bg-white shadow-md flex flex-col gap-4 p-8 my-4">
+            <div className="border-b-2 border-gray-500 pb-2">
+              <p className="text-xl font-semibold">
+                ₹ {rate}{" "}
+                <span className="text-sm font-normal">per sq.ft</span>
+              </p>
+            </div>
+
+            {/* Dimension inputs */}
+            <div className="border-b-2 border-gray-500 pb-4 flex flex-col gap-3">
+              <p className="text-sm font-medium">Dimensions (ft)</p>
+              <div className="grid grid-cols-2 items-center gap-y-3">
+                <p className="text-sm">Length</p>
+                <TextInput
+                  type="number"
+                  placeholder="0"
+                  value={dimensions.length}
+                  min={0}
+                  sizing="sm"
+                  onChange={(e) => setDimensions({ ...dimensions, length: e.target.value })}
+                />
+                <p className="text-sm">Breadth</p>
+                <TextInput
+                  type="number"
+                  placeholder="0"
+                  value={dimensions.breadth}
+                  min={0}
+                  sizing="sm"
+                  onChange={(e) => setDimensions({ ...dimensions, breadth: e.target.value })}
+                />
+                <p className="text-sm">Height</p>
+                <TextInput
+                  type="number"
+                  placeholder="0"
+                  value={dimensions.height}
+                  min={0}
+                  sizing="sm"
+                  onChange={(e) => setDimensions({ ...dimensions, height: e.target.value })}
+                />
+              </div>
+            </div>
+
+            {price > 0 && (
+              <div className="border-b-2 border-gray-500 pb-2 grid grid-cols-2 items-center gap-y-4">
+                <p className="text-sm">Total Price</p>
+                <p className="text-xl font-semibold">₹ {price}</p>
+              </div>
+            )}
+
+            <AddToEventButton />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export async function getServerSideProps() {
+  try {
+    const [platformRes, categoryRes] = await Promise.all([
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/config?code=platform`),
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/category`),
+    ]);
+    const [platformConfig, categoryList] = await Promise.all([
+      platformRes.json(),
+      categoryRes.json(),
+    ]);
+    return {
+      props: {
+        platformConfig: platformConfig || {},
+        categoryList: Array.isArray(categoryList) ? categoryList : [],
+      },
+    };
+  } catch {
+    return { props: { platformConfig: {}, categoryList: [] } };
+  }
+}

--- a/pages/decor/view/platform.js
+++ b/pages/decor/view/platform.js
@@ -244,7 +244,7 @@ export default function PlatformPage({
 
         {/* Center col: Image */}
         <div className="flex flex-col gap-6 md:col-span-2 md:px-8 md:mx-6 md:border-x-4 md:border-x-white">
-          <p className="text-2xl font-semibold text-center tracking-wide uppercase">Platform</p>
+          <p className="text-2xl font-semibold text-center tracking-wide uppercase">Platform <span className="text-base font-normal text-gray-400">(fp01)</span></p>
           <div className="max-h-[500px] w-full bg-white flex items-center justify-center rounded-xl overflow-hidden mx-8 md:mx-16">
             <Image
               src={image}

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -313,7 +313,7 @@ const ClipboardVisual = React.memo(() => (
       alt="Clipboard"
       width={450}
       height={600}
-      className="z-10 relative object-contain"
+      className="z-10 relative object-contain max-w-full h-auto"
     />
   </div>
 ));

--- a/pages/index.js
+++ b/pages/index.js
@@ -1730,10 +1730,10 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
             </motion.div>
 
             {/* Points with Timeline */}
-            <div className="relative mb-12 flex flex-row">
+            <div className="relative mb-12 flex flex-row overflow-x-hidden">
               {/* Vertical Bar Image */}
-              <motion.div 
-                className="flex-shrink-0 mr-4" 
+              <motion.div
+                className="flex-shrink-0 mr-4"
                 style={{ height: '300px', overflow: 'hidden' }}
                 initial={{ opacity: 0, scale: 0.9 }}
                 whileInView={{ opacity: 1, scale: 1 }}
@@ -1922,9 +1922,9 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
               </motion.div>
 
               {/* Points with Timeline */}
-              <div className="relative flex flex-row">
+              <div className="relative flex flex-row overflow-x-hidden">
                 {/* Vertical Bar Image */}
-                <motion.div 
+                <motion.div
                   className="flex-shrink-0 mr-6" 
                   style={{ height: '400px', overflow: 'hidden' }}
                   initial={{ opacity: 0, scale: 0.9 }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -465,9 +465,8 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
       .then((response) => {
         // Use EXACT same check as login
         if (response.message === "Login Successful" && response.token) {
-          // OTP verified successfully (user created/logged in, but we'll just submit form)
-          // Don't store the token, just proceed with form submission
-          submitWeddingForm();
+          // OTP verified successfully - pass true for Verified
+          submitWeddingForm(true);
         } else {
           // Use EXACT same error handling as login
           setOtpError(response.message || "Invalid OTP. Please try again.");
@@ -482,7 +481,7 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
       });
   };
 
-  const submitWeddingForm = async () => {
+  const submitWeddingForm = async (isVerified = false) => {
     const budgetMap = {
       "5-10": 750000,
       "10-15": 1250000,
@@ -496,7 +495,7 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
     formDataToSend.append('phone', `${countryCode}${weddingFormData.phone}` || '');
     formDataToSend.append('budget', budgetValue.toString());
     formDataToSend.append('date', weddingFormData.date || '');
-    formDataToSend.append('formType', 'wedding-requirements');
+    formDataToSend.append('Verified', isVerified ? "Verified" : "Pending");
 
     await fetch(
       `${process.env.NEXT_PUBLIC_SHEET_URL}`,
@@ -542,10 +541,10 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
     if (countryCode === "+91") {
       await sendOTP();
     } else {
-      // For non-India, submit directly
+      // For non-India, submit directly - pass false for Pending
       setIsWeddingSubmitting(true);
       try {
-        await submitWeddingForm();
+        await submitWeddingForm(false);
       } catch (error) {
         console.error("Error submitting form:", error);
         setToast({ show: true, message: "Error submitting form. Please try again.", type: "error" });

--- a/pages/index.js
+++ b/pages/index.js
@@ -751,7 +751,7 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
         }
         setDecorIndex(item);
       }
-    }, 2000);
+    }, 4000);
     return () => {
       clearInterval(intervalId);
     };
@@ -1158,7 +1158,13 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
       </main>
 
       {/* Makeup Artist Section */}
-      <section className="w-full relative pb-10">
+      <motion.section
+        className="w-full relative pb-10"
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        viewport={{ once: true, amount: 0.15 }}
+      >
         <div className="relative w-full">
           <Image
             src="/assets/landing_v2/makeup_desktop.webp"
@@ -1195,10 +1201,17 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
             </Link>
           </div>
         </div>
-      </section>
+      </motion.section>
 
       {/* What our loved ones say section */}
-      <section className="w-full" style={{ backgroundColor: '#F9F8F6' }}>
+      <motion.section
+        className="w-full"
+        style={{ backgroundColor: '#F9F8F6' }}
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        viewport={{ once: true, amount: 0.15 }}
+      >
         <div className="relative w-full">
           {/* Desktop Title Overlay */}
           <div className="hidden md:flex absolute top-20 left-10 lg:left-20 z-10 items-center">
@@ -1323,9 +1336,9 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
             </div>
           </div>
         </div>
-      </section>
+      </motion.section>
 
-      
+
       {/* wedding venue section */}
 {/* 
       <section className="w-full py-6 md:py-24 px-6 md:px-40  md:mt-10">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1158,13 +1158,7 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
       </main>
 
       {/* Makeup Artist Section */}
-      <motion.section
-        className="w-full relative pb-10"
-        initial={{ opacity: 0, y: 40 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: "easeOut" }}
-        viewport={{ once: true, amount: 0.15 }}
-      >
+      <section className="w-full relative pb-10">
         <div className="relative w-full">
           <Image
             src="/assets/landing_v2/makeup_desktop.webp"
@@ -1201,17 +1195,10 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
             </Link>
           </div>
         </div>
-      </motion.section>
+      </section>
 
       {/* What our loved ones say section */}
-      <motion.section
-        className="w-full"
-        style={{ backgroundColor: '#F9F8F6' }}
-        initial={{ opacity: 0, y: 40 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, ease: "easeOut" }}
-        viewport={{ once: true, amount: 0.15 }}
-      >
+      <section className="w-full" style={{ backgroundColor: '#F9F8F6' }}>
         <div className="relative w-full">
           {/* Desktop Title Overlay */}
           <div className="hidden md:flex absolute top-20 left-10 lg:left-20 z-10 items-center">
@@ -1336,7 +1323,7 @@ function Home({ packages, userLoggedIn, setOpenLoginModalv2, setSource }) {
             </div>
           </div>
         </div>
-      </motion.section>
+      </section>
 
 
       {/* wedding venue section */}

--- a/pages/login.js
+++ b/pages/login.js
@@ -286,12 +286,12 @@ export default function Login({ CheckLogin }) {
                     value={data.countryCode}
                     onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                     disabled={data.otpSent}
-                    className="px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                    className="w-28 px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
                     style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
                   >
                     {COUNTRIES.map((c) => (
-                      <option key={`${c.code}-${c.name}`} value={c.code}>
-                        {c.flag} {c.code} {c.name}
+                      <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
+                        {c.flag} {c.code}
                       </option>
                     ))}
                   </select>

--- a/pages/login.js
+++ b/pages/login.js
@@ -288,19 +288,56 @@ export default function Login({ CheckLogin }) {
             {!data.needsSignup && (
               <>
                 <div className="flex gap-2 relative z-30">
-                  <select
-                    value={data.countryCode}
-                    onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
-                    disabled={data.otpSent}
-                    className="w-[120px] px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
-                    style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
-                  >
-                    {COUNTRIES.map((c) => (
-                      <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                        {c.flag} {isOther(c.code) ? "Other" : c.code}
-                      </option>
-                    ))}
-                  </select>
+                  {isOther(data.countryCode) ? (
+                    <div
+                      className="w-[120px] flex items-center px-2 rounded-lg border border-gray-300 bg-white focus-within:ring-2 focus-within:ring-red-600"
+                      style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                    >
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        placeholder="+49"
+                        value={data.customCountryCode}
+                        maxLength={5}
+                        autoFocus
+                        onChange={(e) => {
+                          const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                          const newCustom = "+" + digits;
+                          if (newCustom === "+91") {
+                            setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                          } else {
+                            setData({ ...data, customCountryCode: newCustom });
+                          }
+                        }}
+                        disabled={data.otpSent}
+                        className="flex-1 min-w-0 py-3 bg-transparent border-0 focus:outline-none focus:ring-0"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setData({ ...data, countryCode: "+91", customCountryCode: "+" })}
+                        disabled={data.otpSent}
+                        title="Back to country list"
+                        aria-label="Back to country list"
+                        className="text-gray-500 hover:text-gray-800 text-lg leading-none px-1"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ) : (
+                    <select
+                      value={data.countryCode}
+                      onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                      disabled={data.otpSent}
+                      className="w-[120px] px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                      style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                    >
+                      {COUNTRIES.map((c) => (
+                        <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
+                          {c.flag} {isOther(c.code) ? "Other" : c.code}
+                        </option>
+                      ))}
+                    </select>
+                  )}
                   <input
                     type="tel"
                     inputMode="numeric"
@@ -314,29 +351,6 @@ export default function Login({ CheckLogin }) {
                     style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
                   />
                 </div>
-                {isOther(data.countryCode) && (
-                  <div className="relative z-30">
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      placeholder="+49"
-                      value={data.customCountryCode}
-                      maxLength={5}
-                      onChange={(e) => {
-                        const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                        const newCustom = "+" + digits;
-                        if (newCustom === "+91") {
-                          setData({ ...data, countryCode: "+91", customCountryCode: "+" });
-                        } else {
-                          setData({ ...data, customCountryCode: newCustom });
-                        }
-                      }}
-                      disabled={data.otpSent}
-                      className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
-                      style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
-                    />
-                  </div>
-                )}
                 {data.otpSent && (
                   <div className="relative z-30">
                     <input

--- a/pages/login.js
+++ b/pages/login.js
@@ -324,7 +324,12 @@ export default function Login({ CheckLogin }) {
                       maxLength={5}
                       onChange={(e) => {
                         const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                        setData({ ...data, customCountryCode: "+" + digits });
+                        const newCustom = "+" + digits;
+                        if (newCustom === "+91") {
+                          setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                        } else {
+                          setData({ ...data, customCountryCode: newCustom });
+                        }
                       }}
                       disabled={data.otpSent}
                       className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,13 +1,15 @@
 import { processMobileNumber } from "@/utils/phoneNumber";
+import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
 import { trimTitle } from "@/utils/seo";
 import { Spinner } from "flowbite-react";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Login({ CheckLogin }) {
   const router = useRouter();
   const [data, setData] = useState({
+    countryCode: "+91",
     phone: "",
     loading: false,
     success: false,
@@ -15,79 +17,218 @@ export default function Login({ CheckLogin }) {
     Otp: "",
     ReferenceId: "",
     message: "",
+    // International signup fields (only used when countryCode !== '+91')
+    signupToken: "",
+    needsSignup: false,
+    name: "",
+    email: "",
   });
+
+  useEffect(() => {
+    detectCountryCode().then((code) => {
+      setData((d) => ({ ...d, countryCode: code }));
+    });
+  }, []);
+
+  const country = getCountry(data.countryCode);
+
   const SendOTP = () => {
-    setData({
-      ...data,
-      loading: true,
-    });
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        phone: processMobileNumber(data.phone),
-      }),
-    })
-      .then((response) => response.json())
-      .then((response) => {
-        setData({
-          ...data,
-          loading: false,
-          otpSent: true,
-          ReferenceId: response.ReferenceId,
-        });
+    setData({ ...data, loading: true, message: "" });
+    if (isIndia(data.countryCode)) {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone: processMobileNumber(data.phone) }),
       })
-      .catch((error) => {
-        console.error("There was a problem with the fetch operation:", error);
-      });
+        .then((r) => r.json())
+        .then((response) => {
+          setData({
+            ...data,
+            loading: false,
+            otpSent: true,
+            ReferenceId: response.ReferenceId,
+          });
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    } else {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp/international`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: data.phone,
+          countryCode: data.countryCode,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          setData({
+            ...data,
+            loading: false,
+            otpSent: true,
+            ReferenceId: response.ReferenceId,
+            message: response.message || "OTP sent on WhatsApp",
+          });
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    }
   };
+
   const handleLogin = () => {
-    setData({
-      ...data,
-      loading: true,
-    });
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
+    setData({ ...data, loading: true });
+    if (isIndia(data.countryCode)) {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: processMobileNumber(data.phone),
+          Otp: data.Otp,
+          ReferenceId: data.ReferenceId,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          if (response.message === "Login Successful" && response.token) {
+            setData({
+              ...data,
+              phone: "",
+              loading: false,
+              success: true,
+              otpSent: false,
+              Otp: "",
+              ReferenceId: "",
+              message: "",
+            });
+            localStorage.setItem("token", response.token);
+            router.push("/decor/view");
+            CheckLogin();
+          } else {
+            setData({ ...data, loading: false, Otp: "", message: response.message });
+          }
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    } else {
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/verify/international`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phone: data.phone,
+          countryCode: data.countryCode,
+          otp: data.Otp,
+          referenceId: data.ReferenceId,
+        }),
+      })
+        .then((r) => r.json())
+        .then((response) => {
+          if (response.userExists && response.token) {
+            localStorage.setItem("token", response.token);
+            setData({
+              ...data,
+              phone: "",
+              loading: false,
+              success: true,
+              otpSent: false,
+              Otp: "",
+              ReferenceId: "",
+              message: "",
+            });
+            router.push("/decor/view");
+            CheckLogin();
+          } else if (response.userExists === false && response.signupToken) {
+            setData({
+              ...data,
+              loading: false,
+              needsSignup: true,
+              signupToken: response.signupToken,
+              message: "",
+            });
+          } else {
+            setData({
+              ...data,
+              loading: false,
+              Otp: "",
+              message: response.message || "Invalid or expired OTP",
+            });
+          }
+        })
+        .catch((error) => {
+          console.error("There was a problem with the fetch operation:", error);
+          setData({ ...data, loading: false });
+        });
+    }
+  };
+
+  const handleSignup = () => {
+    setData({ ...data, loading: true });
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup/international`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        phone: processMobileNumber(data.phone),
-        Otp: data.Otp,
-        ReferenceId: data.ReferenceId,
+        phone: data.phone,
+        countryCode: data.countryCode,
+        name: data.name,
+        email: data.email,
+        signupToken: data.signupToken,
       }),
     })
-      .then((response) => response.json())
+      .then((r) => r.json())
       .then((response) => {
-        if (response.message === "Login Successful" && response.token) {
+        if (response.token) {
+          localStorage.setItem("token", response.token);
           setData({
             ...data,
             phone: "",
             loading: false,
             success: true,
             otpSent: false,
+            needsSignup: false,
             Otp: "",
             ReferenceId: "",
+            signupToken: "",
+            name: "",
+            email: "",
             message: "",
           });
-          localStorage.setItem("token", response.token);
           router.push("/decor/view");
           CheckLogin();
         } else {
           setData({
             ...data,
             loading: false,
-            Otp: "",
-            message: response.message,
+            message: response.message || "Account creation failed",
           });
         }
       })
       .catch((error) => {
         console.error("There was a problem with the fetch operation:", error);
+        setData({ ...data, loading: false });
       });
   };
+
+  const handleSubmit = () => {
+    if (data.needsSignup) {
+      if (!data.name || !data.email) {
+        setData({ ...data, message: "Name and email are required" });
+        return;
+      }
+      handleSignup();
+      return;
+    }
+    if (data.otpSent) {
+      handleLogin();
+    } else {
+      SendOTP();
+    }
+  };
+
   return (
     <>
       <Head>
@@ -115,9 +256,9 @@ export default function Login({ CheckLogin }) {
             </div>
           </div>
         </div>
-        
+
         {/* Right side - Background image area (40% width) */}
-        <div 
+        <div
           className="flex-1 md:w-2/5 relative"
           style={{
             backgroundImage: 'url("/assets/background/bg-newSignin.webp")',
@@ -127,52 +268,84 @@ export default function Login({ CheckLogin }) {
           }}
         >
           {/* Login form overlay */}
-          <div 
+          <div
             className="absolute inset-0 bg-white/30 flex flex-col justify-center items-center z-10 px-4 py-8 shadow-lg md:shadow-none"
             style={{
               boxShadow: "0px 4px 4px 0px #00000040"
             }}
           >
-          
-          <h2 className="text-2xl font-bold text-gray-800 mb-8 z-20">Sign in</h2>
+
+          <h2 className="text-2xl font-bold text-gray-800 mb-8 z-20">
+            {data.needsSignup ? "Create your account" : "Sign in"}
+          </h2>
           <div className="w-full max-w-sm space-y-6 z-20">
-            <div className="relative z-30">
-              <input
-                type="text"
-                placeholder="Phone number"
-                value={data.phone}
-                onChange={(e) =>
-                  setData({
-                    ...data,
-                    phone: e.target.value,
-                  })
-                }
-                name="phone"
-                className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
-                style={{
-                  boxShadow: "0px 4px 4px 0px #00000040"
-                }}
-              />
-            </div>
-            {data.otpSent && (
-              <div className="relative z-30">
-                <input
-                  type="text"
-                  placeholder="OTP"
-                  value={data.Otp}
-                  onChange={(e) =>
-                    setData({
-                      ...data,
-                      Otp: e.target.value,
-                    })
-                  }
-                  name="otp"
-                  className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
-                  style={{
-                    boxShadow: "0px 4px 4px 0px #00000040"
-                  }}
-                />
-              </div>
+            {!data.needsSignup && (
+              <>
+                <div className="flex gap-2 relative z-30">
+                  <select
+                    value={data.countryCode}
+                    onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                    disabled={data.otpSent}
+                    className="px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                    style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                  >
+                    {COUNTRIES.map((c) => (
+                      <option key={`${c.code}-${c.name}`} value={c.code}>
+                        {c.flag} {c.code} {c.name}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="tel"
+                    inputMode="numeric"
+                    placeholder={`${country.digits} digits`}
+                    value={data.phone}
+                    maxLength={country.digits}
+                    onChange={(e) => setData({ ...data, phone: e.target.value.replace(/\D/g, "") })}
+                    disabled={data.otpSent}
+                    name="phone"
+                    className="flex-1 min-w-0 px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                    style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                  />
+                </div>
+                {data.otpSent && (
+                  <div className="relative z-30">
+                    <input
+                      type="text"
+                      placeholder="OTP"
+                      value={data.Otp}
+                      onChange={(e) => setData({ ...data, Otp: e.target.value })}
+                      name="otp"
+                      className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
+                      style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+            {data.needsSignup && (
+              <>
+                <div className="relative z-30">
+                  <input
+                    type="text"
+                    placeholder="Name"
+                    value={data.name}
+                    onChange={(e) => setData({ ...data, name: e.target.value })}
+                    className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                    style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                  />
+                </div>
+                <div className="relative z-30">
+                  <input
+                    type="email"
+                    placeholder="Email"
+                    value={data.email}
+                    onChange={(e) => setData({ ...data, email: e.target.value })}
+                    className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                    style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                  />
+                </div>
+              </>
             )}
             {data.message && <p className="text-red-500 text-sm z-30">{data.message}</p>}
             <div className="flex justify-center w-full">
@@ -183,22 +356,22 @@ export default function Login({ CheckLogin }) {
                   backgroundColor: "#840032",
                   boxShadow: "0px 4px 4px 0px #00000040"
                 }}
-                onClick={() => {
-                  data.otpSent ? handleLogin() : SendOTP();
-                }}
+                onClick={handleSubmit}
               >
                 {data.loading ? (
                   <>
                     <Spinner size="sm" />
                     <span className="pl-3">Loading...</span>
                   </>
+                ) : data.needsSignup ? (
+                  <>Create account</>
                 ) : (
                   <>Login</>
                 )}
               </button>
             </div>
             <p className="text-center text-sm text-gray-600 mb-4 md:mb-0">
-              Not signed in yet?               <span 
+              Not signed in yet?               <span
                 className="text-red-800 font-semibold cursor-pointer hover:underline"
                 onClick={() => {
                   router.push('/signup');

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,5 +1,5 @@
 import { processMobileNumber } from "@/utils/phoneNumber";
-import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
+import { COUNTRIES, getCountry, isIndia, isOther, isValidCustomCode, effectiveCountryCode, detectCountryCode } from "@/utils/countries";
 import { trimTitle } from "@/utils/seo";
 import { Spinner } from "flowbite-react";
 import Head from "next/head";
@@ -10,6 +10,7 @@ export default function Login({ CheckLogin }) {
   const router = useRouter();
   const [data, setData] = useState({
     countryCode: "+91",
+    customCountryCode: "+",
     phone: "",
     loading: false,
     success: false,
@@ -17,7 +18,7 @@ export default function Login({ CheckLogin }) {
     Otp: "",
     ReferenceId: "",
     message: "",
-    // International signup fields (only used when countryCode !== '+91')
+    // International signup fields (only used when effective code !== '+91')
     signupToken: "",
     needsSignup: false,
     name: "",
@@ -31,10 +32,11 @@ export default function Login({ CheckLogin }) {
   }, []);
 
   const country = getCountry(data.countryCode);
+  const effectiveCC = effectiveCountryCode(data.countryCode, data.customCountryCode);
 
   const SendOTP = () => {
     setData({ ...data, loading: true, message: "" });
-    if (isIndia(data.countryCode)) {
+    if (isIndia(effectiveCC)) {
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -59,7 +61,7 @@ export default function Login({ CheckLogin }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phone: data.phone,
-          countryCode: data.countryCode,
+          countryCode: effectiveCC,
         }),
       })
         .then((r) => r.json())
@@ -81,7 +83,7 @@ export default function Login({ CheckLogin }) {
 
   const handleLogin = () => {
     setData({ ...data, loading: true });
-    if (isIndia(data.countryCode)) {
+    if (isIndia(effectiveCC)) {
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -121,7 +123,7 @@ export default function Login({ CheckLogin }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           phone: data.phone,
-          countryCode: data.countryCode,
+          countryCode: effectiveCC,
           otp: data.Otp,
           referenceId: data.ReferenceId,
         }),
@@ -173,7 +175,7 @@ export default function Login({ CheckLogin }) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         phone: data.phone,
-        countryCode: data.countryCode,
+        countryCode: effectiveCC,
         name: data.name,
         email: data.email,
         signupToken: data.signupToken,
@@ -220,6 +222,10 @@ export default function Login({ CheckLogin }) {
         return;
       }
       handleSignup();
+      return;
+    }
+    if (isOther(data.countryCode) && !isValidCustomCode(data.customCountryCode)) {
+      setData({ ...data, message: "Enter a valid country code (e.g. +49)" });
       return;
     }
     if (data.otpSent) {
@@ -286,12 +292,12 @@ export default function Login({ CheckLogin }) {
                     value={data.countryCode}
                     onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                     disabled={data.otpSent}
-                    className="w-28 px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                    className="w-[120px] px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
                     style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
                   >
                     {COUNTRIES.map((c) => (
                       <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                        {c.flag} {c.code}
+                        {c.flag} {isOther(c.code) ? "Other" : c.code}
                       </option>
                     ))}
                   </select>
@@ -308,6 +314,24 @@ export default function Login({ CheckLogin }) {
                     style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
                   />
                 </div>
+                {isOther(data.countryCode) && (
+                  <div className="relative z-30">
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      placeholder="+49"
+                      value={data.customCountryCode}
+                      maxLength={5}
+                      onChange={(e) => {
+                        const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                        setData({ ...data, customCountryCode: "+" + digits });
+                      }}
+                      disabled={data.otpSent}
+                      className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                      style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                    />
+                  </div>
+                )}
                 {data.otpSent && (
                   <div className="relative z-30">
                     <input

--- a/pages/makeup-and-beauty/artists/[vendorId].js
+++ b/pages/makeup-and-beauty/artists/[vendorId].js
@@ -1898,7 +1898,7 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
 
           })()}
 
-          /* MODAL */
+          {/* MODAL */}
           <Modal
           show={galleryViewAll}
           onClose={()=>setGalleryViewAll(false)}

--- a/pages/makeup-and-beauty/artists/[vendorId].js
+++ b/pages/makeup-and-beauty/artists/[vendorId].js
@@ -72,6 +72,38 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
   });
   const [reviewSubmitting, setReviewSubmitting] = useState(false);
 
+  const renderMedia = (url, className = "") => {
+    if (!url) return null;
+  
+    const videoExtensions = [".mp4", ".mov", ".webm", ".ogg"];
+    const isVideo = videoExtensions.some((ext) =>
+      url.toLowerCase().includes(ext)
+    );
+  
+    if (isVideo) {
+      return (
+        <video
+          src={url}
+          className={className}
+          autoPlay
+          muted
+          loop
+          playsInline
+        />
+      );
+    }
+  
+    return (
+      <img
+        src={url}
+        className={className}
+        onError={(e) => {
+          e.target.src = "/assets/images/placeholder.jpg";
+        }}
+      />
+    );
+  };
+
   useEffect(() => {
     const generateShortUrl = async () => {
       try {
@@ -1384,7 +1416,7 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
       </div>
 
 
-      {/* Desktop wedsy packages section */}
+      {/* Desktop personal packages section */}
 <div className="bg-[#f4f4f4] px-24 py-12 pt-32 hidden md:block">
   <p className="text-2xl font-semibold text-center">Make up Artist Packages</p>
   <div className="relative pt-12 flex items-center justify-center">
@@ -1641,421 +1673,268 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
         </div>
       </div> */}
         {/* Gallery Section - Only show if images exist */}
-        {vendor?.gallery?.photos && vendor.gallery.photos.length > 0 && (
+          {vendor?.gallery?.photos && vendor.gallery.photos.length > 0 && (
           <>
-            <style dangerouslySetInnerHTML={{__html: `
-              .scrollbar-hide {
-                -ms-overflow-style: none;
-                scrollbar-width: none;
-              }
-              .scrollbar-hide::-webkit-scrollbar {
-                display: none;
-              }
-            `}} />
-            <div className="bg-[#f4f4f4] mt-8 uppercase px-6 md:px-24 py-8 md:py-16 text-2xl md:text-3xl font-semibold md:mt-0 md:mb-0 text-center">
-          {"Gallery"}
-        </div>
-            
-            {(() => {
-              const photos = vendor.gallery.photos;
-              const totalPhotos = photos.length;
-              const hasMoreThanFive = totalPhotos > 5;
+          <style dangerouslySetInnerHTML={{__html: `
+          .scrollbar-hide {
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+          }
+          .scrollbar-hide::-webkit-scrollbar {
+          display: none;
+          }
+          `}} />
 
-              // For 1-4 images: Use a clean horizontal row layout
-              if (totalPhotos <= 4) {
-                return (
-                  <div className="bg-[#f4f4f4] pb-12 px-6 md:px-28">
-                    {/* Mobile: Horizontal scrollable row */}
-                    <div className="flex md:hidden gap-3 overflow-x-auto pb-2 scrollbar-hide snap-x snap-mandatory">
-                      {photos.map((photo, index) => (
-                        <div
-                          key={index}
-                          className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg snap-center"
-                          onClick={() => {
-                            setCurrentImageIndex(index);
-                            setGalleryViewAll(true);
-                          }}
-                        >
-                          <img
-                            src={photo}
-                            alt={`Gallery image ${index + 1}`}
-                            className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-110 transition-transform duration-300"
-                            onError={(e) => {
-                              e.target.src = '/assets/images/placeholder.jpg';
-                            }}
-                          />
-                          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity duration-300"></div>
-                        </div>
-                      ))}
-                    </div>
-                    {/* Desktop: Grid layout */}
-                    <div className={`hidden md:grid gap-3 md:gap-4 ${
-                      totalPhotos === 1 
-                        ? 'grid-cols-1 max-w-4xl mx-auto' 
-                        : totalPhotos === 2
-                        ? 'grid-cols-2 max-w-5xl mx-auto'
-                        : totalPhotos === 3
-                        ? 'grid-cols-3 max-w-6xl mx-auto'
-                        : 'grid-cols-4 max-w-7xl mx-auto'
-                    }`}>
-                      {photos.map((photo, index) => (
-                        <div
-                          key={index}
-                          className="relative aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg hover:shadow-xl transition-all duration-300"
-                          onClick={() => {
-                            setCurrentImageIndex(index);
-                            setGalleryViewAll(true);
-                          }}
-                        >
-                          <img
-                            src={photo}
-                            alt={`Gallery image ${index + 1}`}
-                            className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-110 transition-transform duration-300"
-                            onError={(e) => {
-                              e.target.src = '/assets/images/placeholder.jpg';
-                            }}
-                          />
-                          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity duration-300"></div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                );
-              }
+          <div className="bg-[#f4f4f4] mt-8 uppercase px-6 md:px-24 py-8 md:py-16 text-2xl md:text-3xl font-semibold text-center">
+          Gallery
+          </div>
 
-              // For 5+ images: Show preview or expanded grid
-              if (galleryExpanded) {
-                // Expanded view: Horizontal scroll on mobile, grid on desktop
-                return (
-                  <div className="bg-[#f4f4f4] pb-12 px-6 md:px-28">
-                    {/* Mobile: Horizontal scrollable row */}
-                    <div className="flex md:hidden gap-3 overflow-x-auto pb-2 scrollbar-hide snap-x snap-mandatory">
-                      {photos.map((photo, index) => (
-                        <div
-                          key={index}
-                          className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg snap-center"
-                          onClick={() => {
-                            setCurrentImageIndex(index);
-                            setGalleryViewAll(true);
-                          }}
-                        >
-                          <img
-                            src={photo}
-                            alt={`Gallery image ${index + 1}`}
-                            className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-110 transition-transform duration-300"
-                            onError={(e) => {
-                              e.target.src = '/assets/images/placeholder.jpg';
-                            }}
-                          />
-                          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity duration-300"></div>
-                        </div>
-                      ))}
-                    </div>
-                    {/* Desktop: Grid layout */}
-                    <div className="hidden md:grid grid-cols-5 gap-2 md:gap-3">
-                      {photos.map((photo, index) => (
-                        <div
-                          key={index}
-                          className="relative aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg hover:shadow-xl transition-all duration-300"
-                          onClick={() => {
-                            setCurrentImageIndex(index);
-                            setGalleryViewAll(true);
-                          }}
-                        >
-                          <img
-                            src={photo}
-                            alt={`Gallery image ${index + 1}`}
-                            className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-110 transition-transform duration-300"
-                            onError={(e) => {
-                              e.target.src = '/assets/images/placeholder.jpg';
-                            }}
-                          />
-                          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity duration-300"></div>
-                        </div>
-                      ))}
-                    </div>
-                    
-                    {/* Collapse button */}
-                    <div className="flex justify-center mt-6">
-                      <button
-                        onClick={() => setGalleryExpanded(false)}
-                        className="bg-[#840032] text-white rounded-lg px-8 py-2 hover:bg-[#6b0028] transition-colors font-semibold"
-                      >
-                        VIEW LESS
-                      </button>
-                    </div>
-                  </div>
-                );
-              }
+          {(() => {
+          const photos = vendor.gallery.photos;
+          const totalPhotos = photos.length;
+          const hasMoreThanFive = totalPhotos > 5;
 
-              // Preview view: Zomato-style layout (first 4 + View More)
-              return (
-                <>
-                  {/* Mobile: Horizontal scrollable row */}
-                  <div className="flex md:hidden bg-[#f4f4f4] gap-3 overflow-x-auto pb-12 px-6 scrollbar-hide snap-x snap-mandatory">
-                    {photos.slice(0, hasMoreThanFive ? 4 : 5).map((photo, index) => (
-                      <div
-                        key={index}
-                        className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg snap-center"
-                        onClick={() => {
-                          setCurrentImageIndex(index);
-                          setGalleryViewAll(true);
-                        }}
-                      >
-                        <img
-                          src={photo}
-                          alt={`Gallery image ${index + 1}`}
-                          className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-110 transition-transform duration-300"
-                          onError={(e) => {
-                            e.target.style.display = 'none';
-                          }}
-                        />
-                        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity duration-300"></div>
-                      </div>
-                    ))}
-                    {hasMoreThanFive && (
-                      <div
-                        className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl bg-[#333] flex flex-col items-center justify-center text-white hover:bg-[#444] transition cursor-pointer snap-center"
-                        onClick={() => setGalleryExpanded(true)}
-                      >
-                        <div className="text-sm font-semibold tracking-wider mb-3">
-                          VIEW MORE
-                        </div>
-                        <div className="w-8 h-8 border-2 border-white rounded-full flex items-center justify-center">
-                          <span className="text-lg">›</span>
-                        </div>
-                        <div className="text-xs mt-2 opacity-80">
-                          +{totalPhotos - 4} more
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                  {/* Desktop: Zomato-style grid */}
-                  <div className="hidden md:grid bg-[#f4f4f4] grid-cols-5 md:grid-rows-2 pb-12 gap-2 md:px-28">
-                  {/* S1 - Large image (first photo) */}
-                  <div 
-                    className="bg-gray-300 aspect-square rounded-xl md:row-span-2 md:col-span-2 relative overflow-hidden cursor-pointer group"
-                    onClick={() => {
-                      setCurrentImageIndex(0);
-                      setGalleryViewAll(true);
-                    }}
-                  >
-                    <img
-                      src={photos[0]}
-                      alt={`Gallery image 1`}
-                      className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-                      onError={(e) => {
-                        e.target.style.display = 'none';
-                      }}
-                    />
-                  </div>
+          /* 1–4 MEDIA */
+          if (totalPhotos <= 4) {
+          return (
+          <div className="bg-[#f4f4f4] pb-12 px-6 md:px-28">
 
-                  {/* S2 - Second photo */}
-                  <div 
-                    className="bg-gray-300 aspect-square rounded-xl relative overflow-hidden cursor-pointer group"
-                    onClick={() => {
-                      setCurrentImageIndex(1);
-                      setGalleryViewAll(true);
-                    }}
-                  >
-                    <img
-                      src={photos[1]}
-                      alt={`Gallery image 2`}
-                      className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-                      onError={(e) => {
-                        e.target.style.display = 'none';
-                      }}
-                    />
-                  </div>
-
-                  {/* S3 - Third photo (rectangular) */}
-                  <div 
-                    className="bg-gray-300 aspect-square rounded-xl md:col-span-2 md:aspect-auto relative overflow-hidden cursor-pointer group"
-                    onClick={() => {
-                      setCurrentImageIndex(2);
-                      setGalleryViewAll(true);
-                    }}
-                  >
-                    <img
-                      src={photos[2]}
-                      alt={`Gallery image 3`}
-                      className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-                      onError={(e) => {
-                        e.target.style.display = 'none';
-                      }}
-                    />
-                  </div>
-
-                  {/* S4 - Fourth photo */}
-                  <div 
-                    className="bg-gray-300 aspect-square rounded-xl relative overflow-hidden cursor-pointer group"
-                    onClick={() => {
-                      setCurrentImageIndex(3);
-                      setGalleryViewAll(true);
-                    }}
-                  >
-                    <img
-                      src={photos[3]}
-                      alt={`Gallery image 4`}
-                      className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-                      onError={(e) => {
-                        e.target.style.display = 'none';
-                      }}
-                    />
-                  </div>
-
-                  {/* S5 - Fifth photo OR "View More" overlay */}
-                  {hasMoreThanFive ? (
-                    <div
-                      className="bg-[#333] aspect-square rounded-xl flex flex-col items-center justify-center text-white hover:bg-[#444] transition cursor-pointer"
-                      onClick={() => setGalleryExpanded(true)}
+          {/* MOBILE */}
+          <div className="flex md:hidden gap-3 overflow-x-auto pb-2 scrollbar-hide snap-x snap-mandatory">
+          {photos.map((photo, index) => (
+          <div
+          key={index}
+          className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg snap-center"
+          onClick={()=>{
+          setCurrentImageIndex(index);
+          setGalleryViewAll(true);
+          }}
           >
-            <div className="text-sm font-semibold tracking-wider mb-3">
-              VIEW MORE
-            </div>
-            <div className="w-8 h-8 border-2 border-white rounded-full flex items-center justify-center">
-              <span className="text-lg">›</span>
-            </div>
-                      <div className="text-xs mt-2 opacity-80">
-                        +{totalPhotos - 4} more
-                      </div>
-                    </div>
-                  ) : (
-                    <div 
-                      className="bg-gray-300 aspect-square rounded-xl relative overflow-hidden cursor-pointer group"
-                      onClick={() => {
-                        setCurrentImageIndex(4);
-                        setGalleryViewAll(true);
-                      }}
-                    >
-                      <img
-                        src={photos[4]}
-                        alt={`Gallery image 5`}
-                        className="absolute top-0 left-0 h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-                        onError={(e) => {
-                          e.target.style.display = 'none';
-                        }}
-                      />
-                    </div>
-                  )}
-                  </div>
-                </>
-              );
-            })()}
 
-            {/* Zomato-style Gallery Modal (Lightbox) */}
-            <Modal 
-              show={galleryViewAll} 
-              onClose={() => setGalleryViewAll(false)}
-              size="7xl"
-              className="gallery-modal"
-            >
-              <style dangerouslySetInnerHTML={{__html: `
-                .gallery-modal [data-modal-backdrop] {
-                  backdrop-filter: blur(12px) !important;
-                  -webkit-backdrop-filter: blur(12px) !important;
-                  background-color: rgba(0, 0, 0, 0.75) !important;
-                }
-              `}} />
-              <Modal.Body className="relative bg-black/80 backdrop-blur-2xl p-0 overflow-hidden">
-                {/* Close button */}
-                <button
-                  onClick={() => setGalleryViewAll(false)}
-                  className="absolute top-4 right-4 z-50 text-white hover:text-gray-300 transition-colors"
-                  style={{ fontSize: '24px', lineHeight: '1' }}
-                >
-                  <MdClear size={32} />
-                </button>
+          {renderMedia(photo,"absolute top-0 left-0 h-full w-full object-cover")}
 
-                {/* Gallery title */}
-                <div className="absolute top-4 left-4 z-50 text-white text-xl font-semibold uppercase">
-                  Gallery
-        </div>
-        
-                {/* Main image container */}
-                {vendor?.gallery?.photos && vendor.gallery.photos.length > 0 && (
-                  <div className="relative w-full" style={{ minHeight: '70vh' }}>
-                    <img
-                      src={vendor.gallery.photos[currentImageIndex]}
-                      alt={`Gallery image ${currentImageIndex + 1}`}
-                      className="w-full h-auto object-contain"
-                      style={{ maxHeight: '80vh' }}
-                      onError={(e) => {
-                        e.target.src = '/assets/images/placeholder.jpg';
-                      }}
-                    />
+          <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity"></div>
+          </div>
+          ))}
+          </div>
 
-                    {/* Image counter */}
-                    <div className="absolute bottom-4 right-4 bg-black bg-opacity-50 text-white px-4 py-2 rounded text-sm">
-                      {currentImageIndex + 1} of {vendor.gallery.photos.length}
-                    </div>
+          {/* DESKTOP */}
+          <div className={`hidden md:grid gap-3 md:gap-4 ${
+          totalPhotos === 1
+          ? "grid-cols-1 max-w-4xl mx-auto"
+          : totalPhotos === 2
+          ? "grid-cols-2 max-w-5xl mx-auto"
+          : totalPhotos === 3
+          ? "grid-cols-3 max-w-6xl mx-auto"
+          : "grid-cols-4 max-w-7xl mx-auto"
+          }`}>
+          {photos.map((photo,index)=>(
+          <div
+          key={index}
+          className="relative aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg"
+          onClick={()=>{
+          setCurrentImageIndex(index);
+          setGalleryViewAll(true);
+          }}
+          >
 
-                    {/* Navigation arrows */}
-                    {vendor.gallery.photos.length > 1 && (
-                      <>
-                        {/* Left arrow */}
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setCurrentImageIndex((prev) => 
-                              prev === 0 ? vendor.gallery.photos.length - 1 : prev - 1
-                            );
-                          }}
-                          className="absolute left-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 hover:bg-opacity-70 text-white p-3 rounded-full transition-all z-50"
-                          aria-label="Previous image"
-                        >
-                          <FaArrowLeft size={20} />
-                        </button>
+          {renderMedia(photo,"absolute top-0 left-0 h-full w-full object-cover")}
 
-                        {/* Right arrow */}
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setCurrentImageIndex((prev) => 
-                              prev === vendor.gallery.photos.length - 1 ? 0 : prev + 1
-                            );
-                          }}
-                          className="absolute right-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 hover:bg-opacity-70 text-white p-3 rounded-full transition-all z-50"
-                          aria-label="Next image"
-                        >
-                          <FaArrowRight size={20} />
-                        </button>
-                      </>
-                    )}
-                  </div>
-                )}
+          </div>
+          ))}
+          </div>
 
-                {/* Thumbnail strip */}
-                {vendor?.gallery?.photos && vendor.gallery.photos.length > 1 && (
-                  <div className="bg-gray-900 px-4 py-3 overflow-x-auto">
-                    <div className="flex gap-2 justify-center">
-                      {vendor.gallery.photos.map((photo, index) => (
-                        <button
-                          key={index}
-                          onClick={() => setCurrentImageIndex(index)}
-                          className={`flex-shrink-0 w-20 h-20 rounded overflow-hidden border-2 transition-all ${
-                            index === currentImageIndex 
-                              ? 'border-white scale-110' 
-                              : 'border-transparent opacity-60 hover:opacity-100'
-                          }`}
-                        >
-                          <img
-                            src={photo}
-                            alt={`Thumbnail ${index + 1}`}
-                            className="w-full h-full object-cover"
-                            onError={(e) => {
-                              e.target.src = '/assets/images/placeholder.jpg';
-                            }}
-                          />
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </Modal.Body>
-            </Modal>
+          </div>
+          );
+          }
+
+          /* 5+ MEDIA */
+          if(galleryExpanded){
+          return(
+          <div className="bg-[#f4f4f4] pb-12 px-6 md:px-28">
+
+          {/* MOBILE */}
+          <div className="flex md:hidden gap-3 overflow-x-auto pb-2 scrollbar-hide snap-x snap-mandatory">
+          {photos.map((photo,index)=>(
+          <div
+          key={index}
+          className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg snap-center"
+          onClick={()=>{
+          setCurrentImageIndex(index);
+          setGalleryViewAll(true);
+          }}
+          >
+
+          {renderMedia(photo,"absolute top-0 left-0 h-full w-full object-cover")}
+
+          </div>
+          ))}
+          </div>
+
+          {/* DESKTOP */}
+          <div className="hidden md:grid grid-cols-5 gap-2 md:gap-3">
+          {photos.map((photo,index)=>(
+          <div
+          key={index}
+          className="relative aspect-square rounded-xl overflow-hidden cursor-pointer"
+          onClick={()=>{
+          setCurrentImageIndex(index);
+          setGalleryViewAll(true);
+          }}
+          >
+
+          {renderMedia(photo,"absolute top-0 left-0 h-full w-full object-cover")}
+
+          </div>
+          ))}
+          </div>
+
+          <div className="flex justify-center mt-6">
+          <button
+          onClick={()=>setGalleryExpanded(false)}
+          className="bg-[#840032] text-white rounded-lg px-8 py-2"
+          >
+          VIEW LESS
+          </button>
+          </div>
+
+          </div>
+          );
+          }
+
+          /* PREVIEW GRID */
+          return(
+          <>
+          <div className="flex md:hidden bg-[#f4f4f4] gap-3 overflow-x-auto pb-12 px-6 scrollbar-hide snap-x snap-mandatory">
+          {photos.slice(0,hasMoreThanFive?4:5).map((photo,index)=>(
+          <div
+          key={index}
+          className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl overflow-hidden cursor-pointer group shadow-lg snap-center"
+          onClick={()=>{
+          setCurrentImageIndex(index);
+          setGalleryViewAll(true);
+          }}
+          >
+
+          {renderMedia(photo,"absolute top-0 left-0 h-full w-full object-cover")}
+
+          </div>
+          ))}
+
+          {hasMoreThanFive && (
+          <div
+          className="relative flex-shrink-0 w-[85vw] aspect-square rounded-xl bg-[#333] flex flex-col items-center justify-center text-white cursor-pointer snap-center"
+          onClick={()=>setGalleryExpanded(true)}
+          >
+          <div className="text-sm font-semibold mb-3">
+          VIEW MORE
+          </div>
+          <div className="text-xs">
+          +{totalPhotos-4} more
+          </div>
+          </div>
+          )}
+
+          </div>
+
+          {/* DESKTOP GRID */}
+          <div className="hidden md:grid bg-[#f4f4f4] grid-cols-5 md:grid-rows-2 pb-12 gap-2 md:px-28">
+
+          <div
+          className="aspect-square md:row-span-2 md:col-span-2 relative rounded-xl overflow-hidden cursor-pointer"
+          onClick={()=>{
+          setCurrentImageIndex(0);
+          setGalleryViewAll(true);
+          }}
+          >
+          {renderMedia(photos[0],"absolute top-0 left-0 h-full w-full object-cover")}
+          </div>
+
+          <div
+          className="aspect-square relative rounded-xl overflow-hidden cursor-pointer"
+          onClick={()=>{
+          setCurrentImageIndex(1);
+          setGalleryViewAll(true);
+          }}
+          >
+          {renderMedia(photos[1],"absolute top-0 left-0 h-full w-full object-cover")}
+          </div>
+
+          <div
+          className="aspect-square md:col-span-2 relative rounded-xl overflow-hidden cursor-pointer"
+          onClick={()=>{
+          setCurrentImageIndex(2);
+          setGalleryViewAll(true);
+          }}
+          >
+          {renderMedia(photos[2],"absolute top-0 left-0 h-full w-full object-cover")}
+          </div>
+
+          <div
+          className="aspect-square relative rounded-xl overflow-hidden cursor-pointer"
+          onClick={()=>{
+          setCurrentImageIndex(3);
+          setGalleryViewAll(true);
+          }}
+          >
+          {renderMedia(photos[3],"absolute top-0 left-0 h-full w-full object-cover")}
+          </div>
+
+          {!hasMoreThanFive && (
+          <div
+          className="aspect-square relative rounded-xl overflow-hidden cursor-pointer"
+          onClick={()=>{
+          setCurrentImageIndex(4);
+          setGalleryViewAll(true);
+          }}
+          >
+          {renderMedia(photos[4],"absolute top-0 left-0 h-full w-full object-cover")}
+          </div>
+          )}
+
+          </div>
           </>
-        )}
+          );
+
+          })()}
+
+          /* MODAL */
+          <Modal
+          show={galleryViewAll}
+          onClose={()=>setGalleryViewAll(false)}
+          size="7xl"
+          className="gallery-modal"
+          >
+
+          <Modal.Body className="relative bg-black p-0">
+
+          <button
+          onClick={()=>setGalleryViewAll(false)}
+          className="absolute top-4 right-4 text-white z-50"
+          >
+          <MdClear size={32}/>
+          </button>
+
+          {vendor?.gallery?.photos && (
+          <div className="relative w-full flex justify-center items-center">
+
+          {renderMedia(
+          vendor.gallery.photos[currentImageIndex],
+          "max-h-[80vh] object-contain"
+          )}
+
+          <div className="absolute bottom-4 right-4 bg-black/50 text-white px-4 py-2 rounded text-sm">
+          {currentImageIndex+1} of {vendor.gallery.photos.length}
+          </div>
+
+          </div>
+          )}
+
+          </Modal.Body>
+          </Modal>
+
+          </>
+          )}
         
 
 

--- a/pages/makeup-and-beauty/index.js
+++ b/pages/makeup-and-beauty/index.js
@@ -406,22 +406,27 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
 
                   {/* Services & Products Section */}
                   <div className="bg-white flex flex-col p-6 gap-4">
-                    <div className="flex flex-col gap-2">
-                      <h4 className="text-black font-normal uppercase">Services</h4>
-                      <ul className="text-black font-semibold text-xl">
-                        {pkg?.process ? pkg.process.map((i, i1) => (
-                          <li key={i1}>&bull; {i.topic}</li>
-                        )) : <li>No services listed</li>}
-                      </ul>
-                    </div>
-                    <div className="flex flex-col gap-2">
-                      <h4 className="text-black font-normal uppercase">Products</h4>
-                      <ul className="text-black font-semibold text-xl">
-                        {pkg?.products ? pkg.products.split(",").map((p, pIndex) => (
-                          <li key={pIndex}>&bull; {p.trim()}</li>
-                        )) : <li>No products listed</li>}
-                      </ul>
-                    </div>
+
+                  {/* Services */}
+                  <div className="flex flex-col gap-2">
+                    <h4 className="text-black font-normal uppercase">Services</h4>
+                    <ul className="text-black font-semibold text-xl">
+                      {pkg?.process?.length > 0 ? pkg.process.map((i, i1) => (
+                        <li key={i1}>&bull; {i.topic}</li>
+                      )) : <li>No services listed</li>}
+                    </ul>
+                  </div>
+
+                  {/* Products */}
+                  <div className="flex flex-col gap-2">
+                    <h4 className="text-black font-normal uppercase">Products</h4>
+                    <ul className="text-black font-semibold text-xl">
+                      {pkg?.process?.length > 0 ? pkg.process.map((p, pIndex) => (
+                        <li key={pIndex}>&bull; {p.description}</li>
+                      )) : <li>No products listed</li>}
+                    </ul>
+                  </div>
+
                   </div>
 
                   <div
@@ -462,9 +467,9 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
                     {/* Price */}
                     <div className="text-white text-right">
                       {originalPrice && (
-                        <p className="text-xs line-through">₹{toPriceString(originalPrice)}</p>
+                        <p className="text-xs line-through">{toPriceString(discountedPrice)}</p>
                       )}
-                      <p className="text-lg font-bold">₹{toPriceString(discountedPrice)}</p>
+                      <p className="text-lg font-bold">{toPriceString(originalPrice)}</p>
                       <p className="text-xs font-normal">Per Person</p>
                     </div>
                   </div>
@@ -529,18 +534,24 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
           </div>
           {/* Package Grid */}
           {wedsyPackages.length > 0 && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 md:gap-0 px-6 md:px-0 w-full mb-8">
-              {[
-                wedsyPackages[displayWedsyPackages[0]],
-                wedsyPackages[displayWedsyPackages[1]],
-                wedsyPackages[displayWedsyPackages[2]],
-                wedsyPackages[displayWedsyPackages[3]],
-              ].map((pkg, index) => {
+            <div
+              className={`grid 
+              grid-cols-1 
+              sm:grid-cols-2 
+              ${wedsyPackages.length === 1 ? "lg:grid-cols-1 justify-items-center" : ""}
+              ${wedsyPackages.length === 2 ? "lg:grid-cols-2 justify-items-center" : ""}
+              ${wedsyPackages.length === 3 ? "lg:grid-cols-3" : ""}
+              ${wedsyPackages.length >= 4 ? "lg:grid-cols-4" : ""}
+              gap-8 md:gap-0 px-6 md:px-0 w-full mb-8`}
+            >
+              {wedsyPackages
+              .slice(displayWedsyPackages[0], displayWedsyPackages[0] + 4)
+              .map((pkg, index) => {
                 const colorSet = colors[index] || colors[0];
                 return (
                   <div
                     key={pkg?._id}
-                    className="flex flex-col rounded-2xl md:rounded-none overflow-hidden shadow-md md:border-2 md:border-white"
+                    className="flex flex-col w-full max-w-[320px] rounded-2xl md:rounded-none overflow-hidden shadow-md md:border-2 md:border-white"
                   >
                     {/* Package Name Header */}
                     <div
@@ -577,15 +588,18 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
 
                       <h4 className="mb-1 text-black font-normal uppercase relative z-10">Products</h4>
                       <p className="hidden md:block text-black font-semibold text-xl text-center px-4 relative z-10">
-                        {pkg?.products ? pkg.products.split(",").map((p, pIndex) => (
+                        {pkg?.process?.length > 0 ? pkg.process.map((p, pIndex) => (
                           <React.Fragment key={pIndex}>
-                            {p.trim()}
-                            {pIndex < pkg.products.split(",").length - 1 && <br />}
+                            {p.description}
+                            {pIndex < pkg.process.length - 1 && <br />}
                           </React.Fragment>
                         )) : "No products listed"}
                       </p>
+
                       <p className="md:hidden text-black font-normal text-sm text-center px-4 relative z-10">
-                        {pkg?.products || "No products listed"}
+                        {pkg?.process?.length > 0
+                          ? pkg.process.map(i => i.description).join(", ")
+                          : "No products listed"}
                       </p>
                     </div>
 
@@ -633,7 +647,7 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
                       <div className="text-black font-semibold text-right">
                         <p className="text-xs font-normal text-black">Per Person</p>
                         <p className="text-[#840032] font-semibold text-lg">
-                          {toPriceString((pkg?.price || 0) * wedsyPackageTaxMultiply)}
+                          {toPriceString((pkg?.price || 0))}
                         </p>
                       </div>
                     </div>
@@ -643,8 +657,17 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
             </div>
           )}
         </div>
-
-
+        {wedsyPackages.length > 4 && (
+          <div className="flex flex-row justify-center">
+            <Link href="/makeup-and-beauty/wedsy-packages">
+              <button
+                className="rounded-md md:rounded-full bg-black text-white py-2 px-28 mt-4 mb-10"
+              >
+                View More
+              </button>
+            </Link>
+          </div>
+        )}
       </div>
 
 

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -7,7 +7,9 @@ import ProfileHero from "@/components/profile/ProfileHero";
 import StatsGrid from "@/components/profile/StatsGrid";
 import TimelineCard from "@/components/profile/TimelineCard";
 import useProfileData from "@/hooks/useProfileData";
+import { regenerateTimeline } from "@/utils/api/wedding-timeline";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 const MOCK_STATS = [
@@ -23,6 +25,8 @@ const MOCK_INSPIRATION = {
   headline: "Stories of weddings like yours",
   ctaLabel: "Explore",
 };
+
+const REGEN_ERROR_MESSAGES = { SERVICE_UNAVAILABLE: "AI is taking a moment — please try again.", BAD_REQUEST: "Something's off with your event data. Please reload." };
 
 const MOCK_ACCOUNT_ITEMS = [
   { label: "Orders", href: "/my-orders", iconName: "Package" },
@@ -55,8 +59,11 @@ function shouldShowEmpty2(event, eventLoading) {
 }
 
 export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginModalv2 }) {
+  const router = useRouter();
   const [token, setToken] = useState(null);
   const [regenerating, setRegenerating] = useState(false);
+  const [regenerateError, setRegenerateError] = useState(null);
+  const [regenerateResult, setRegenerateResult] = useState(null);
 
   useEffect(() => {
     CheckLogin();
@@ -86,14 +93,21 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     );
   }
 
-  const handleRegenerate = () => {
+  const handleRegenerate = async () => {
+    if (!event?._id || !token) return;
     setRegenerating(true);
-    setTimeout(() => {
-      refetchMilestones();
-      setRegenerating(false);
-      console.log("Mock regenerate complete (real Anthropic call deferred to 1.4.C)");
-    }, 1500);
+    setRegenerateError(null);
+    setRegenerateResult(null);
+    const { data, error } = await regenerateTimeline(event._id, token);
+    if (error) setRegenerateError(error);
+    else { setRegenerateResult(data?.suggestions || { add: [], adjust: [], remove: [] }); await refetchMilestones(); }
+    setRegenerating(false);
   };
+  const explicitEmptyState = router.query.state;
+  const weddingDate = deriveWeddingDate(event);
+  const isEventPast = weddingDate ? new Date(weddingDate) < new Date() : false;
+  const showPastEventCard = isEventPast && !!regenerateResult && !regenerateResult.add?.length && !regenerateResult.adjust?.length && !regenerateResult.remove?.length;
+  const handleCreateNewEvent = () => router.push("/profile?state=empty1");
 
   return (
     <>
@@ -105,11 +119,11 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
           <p className="wedsy-subtitle" style={{ padding: "60px 24px", textAlign: "center" }}>Loading…</p>
         ) : eventError ? (
           <p className="font-serif italic text-[13px] text-wedsy-ink-3 text-center" style={{ padding: "60px 24px" }}>Unable to load your wedding. Please reload.</p>
-        ) : shouldShowEmpty1(event, eventLoading) ? (
+        ) : explicitEmptyState === "empty1" || shouldShowEmpty1(event, eventLoading) ? (
           <EmptyStateStep1
             onContinue={(data) => console.log("Mock create event step 1:", data)}
           />
-        ) : shouldShowEmpty2(event, eventLoading) ? (
+        ) : explicitEmptyState === "empty2" || shouldShowEmpty2(event, eventLoading) ? (
           <EmptyStateStep2
             eventName={event.name || "Your wedding"}
             community={event.community || "Hindu"}
@@ -132,6 +146,14 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             />
             {milestonesLoading && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Loading timeline…</p>}
             {milestonesError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Unable to load timeline. Please reload.</p>}
+            {regenerateError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">{REGEN_ERROR_MESSAGES[regenerateError.code] || "Couldn't regenerate. Please try again."}</p>}
+            {showPastEventCard && (
+              <div className="px-6 mt-4 mb-8 text-center">
+                <p className="font-serif italic text-[15px] text-wedsy-ink leading-snug">Your celebration is complete — we hope it was unforgettable.</p>
+                <p className="font-sans text-[12px] text-wedsy-ink-3 mt-3 mb-3">Planning another?</p>
+                <button onClick={handleCreateNewEvent} className="text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600">Create a new event →</button>
+              </div>
+            )}
             <EventDaysCarousel eventDays={event.eventDays || []} />
             <StatsGrid stats={MOCK_STATS} />
             <InspirationCard

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,110 +1,234 @@
 import { processMobileNumber } from "@/utils/phoneNumber";
+import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
 import { trimTitle } from "@/utils/seo";
 import { Spinner } from "flowbite-react";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Signup({ CheckLogin }) {
   const router = useRouter();
   const [data, setData] = useState({
+    countryCode: "+91",
     phone: "",
     name: "",
+    email: "",
     loading: false,
     success: false,
     otpSent: false,
     Otp: "",
     ReferenceId: "",
+    signupToken: "",
     message: "",
   });
 
+  useEffect(() => {
+    detectCountryCode().then((code) => {
+      setData((d) => ({ ...d, countryCode: code }));
+    });
+  }, []);
+
+  const country = getCountry(data.countryCode);
+
   const handleSignup = async () => {
-    if (await processMobileNumber(data.phone)) {
-      setData({
-        ...data,
-        loading: true,
-      });
-      fetch(`${process.env.NEXT_PUBLIC_API_URL}/enquiry`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: data.name,
-          phone: processMobileNumber(data.phone),
-          verified: true,
-          source: "Signup Page",
-          Otp: data.Otp,
-          ReferenceId: data.ReferenceId,
-        }),
-      })
-        .then((response) => response.json())
-        .then((response) => {
-          if (
-            response.message === "Enquiry Added Successfully" &&
-            response.token
-          ) {
-            setData({
-              ...data,
-              phone: "",
-              name: "",
-              loading: false,
-              success: true,
-              otpSent: false,
-              Otp: "",
-              ReferenceId: "",
-              message: "",
-            });
-            localStorage.setItem("token", response.token);
-            router.push("/decor/view");
-            CheckLogin();
-          } else {
-            setData({
-              ...data,
-              loading: false,
-              Otp: "",
-              message: response.message,
-            });
-          }
+    if (isIndia(data.countryCode)) {
+      // Existing Indian flow: single /enquiry call verifies OTP + creates record
+      if (await processMobileNumber(data.phone)) {
+        setData({ ...data, loading: true });
+        fetch(`${process.env.NEXT_PUBLIC_API_URL}/enquiry`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: data.name,
+            phone: processMobileNumber(data.phone),
+            verified: true,
+            source: "Signup Page",
+            Otp: data.Otp,
+            ReferenceId: data.ReferenceId,
+          }),
         })
-        .catch((error) => {
-          console.error("There was a problem with the fetch operation:", error);
+          .then((r) => r.json())
+          .then((response) => {
+            if (response.message === "Enquiry Added Successfully" && response.token) {
+              setData({
+                ...data,
+                phone: "",
+                name: "",
+                loading: false,
+                success: true,
+                otpSent: false,
+                Otp: "",
+                ReferenceId: "",
+                message: "",
+              });
+              localStorage.setItem("token", response.token);
+              router.push("/decor/view");
+              CheckLogin();
+            } else {
+              setData({ ...data, loading: false, Otp: "", message: response.message });
+            }
+          })
+          .catch((error) => {
+            console.error("There was a problem with the fetch operation:", error);
+            setData({ ...data, loading: false });
+          });
+      } else {
+        alert("Please enter valid mobile number");
+      }
+      return;
+    }
+
+    // International flow: verify, then signup
+    if (!data.email) {
+      setData({ ...data, message: "Email is required" });
+      return;
+    }
+    setData({ ...data, loading: true });
+    try {
+      const verifyRes = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/verify/international`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            phone: data.phone,
+            countryCode: data.countryCode,
+            otp: data.Otp,
+            referenceId: data.ReferenceId,
+          }),
+        }
+      ).then((r) => r.json());
+
+      if (verifyRes.userExists && verifyRes.token) {
+        // Already have an account — log them straight in
+        localStorage.setItem("token", verifyRes.token);
+        setData({
+          ...data,
+          phone: "",
+          name: "",
+          email: "",
+          loading: false,
+          success: true,
+          otpSent: false,
+          Otp: "",
+          ReferenceId: "",
+          message: "",
         });
-    } else {
-      alert("Please enter valid mobile number");
+        router.push("/decor/view");
+        CheckLogin();
+        return;
+      }
+
+      if (verifyRes.userExists !== false || !verifyRes.signupToken) {
+        setData({
+          ...data,
+          loading: false,
+          Otp: "",
+          message: verifyRes.message || "Invalid or expired OTP",
+        });
+        return;
+      }
+
+      const signupRes = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/signup/international`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            phone: data.phone,
+            countryCode: data.countryCode,
+            name: data.name,
+            email: data.email,
+            signupToken: verifyRes.signupToken,
+          }),
+        }
+      ).then((r) => r.json());
+
+      if (signupRes.token) {
+        localStorage.setItem("token", signupRes.token);
+        setData({
+          ...data,
+          phone: "",
+          name: "",
+          email: "",
+          loading: false,
+          success: true,
+          otpSent: false,
+          Otp: "",
+          ReferenceId: "",
+          signupToken: "",
+          message: "",
+        });
+        router.push("/decor/view");
+        CheckLogin();
+      } else {
+        setData({
+          ...data,
+          loading: false,
+          message: signupRes.message || "Account creation failed",
+        });
+      }
+    } catch (error) {
+      console.error("There was a problem with the fetch operation:", error);
+      setData({ ...data, loading: false });
     }
   };
 
   const SendOTP = async () => {
-    if (await processMobileNumber(data.phone)) {
-      setData({
-        ...data,
-        loading: true,
-      });
-      fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          phone: processMobileNumber(data.phone),
-        }),
-      })
-        .then((response) => response.json())
-        .then((response) => {
-          setData({
-            ...data,
-            loading: false,
-            otpSent: true,
-            ReferenceId: response.ReferenceId,
-          });
+    if (isIndia(data.countryCode)) {
+      if (await processMobileNumber(data.phone)) {
+        setData({ ...data, loading: true });
+        fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ phone: processMobileNumber(data.phone) }),
         })
-        .catch((error) => {
-          console.error("There was a problem with the fetch operation:", error);
-        });
-    } else {
-      alert("Please enter valid mobile number");
+          .then((r) => r.json())
+          .then((response) => {
+            setData({
+              ...data,
+              loading: false,
+              otpSent: true,
+              ReferenceId: response.ReferenceId,
+            });
+          })
+          .catch((error) => {
+            console.error("There was a problem with the fetch operation:", error);
+            setData({ ...data, loading: false });
+          });
+      } else {
+        alert("Please enter valid mobile number");
+      }
+      return;
     }
+
+    if (!data.phone) {
+      alert("Please enter valid mobile number");
+      return;
+    }
+    setData({ ...data, loading: true });
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp/international`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        phone: data.phone,
+        countryCode: data.countryCode,
+      }),
+    })
+      .then((r) => r.json())
+      .then((response) => {
+        setData({
+          ...data,
+          loading: false,
+          otpSent: true,
+          ReferenceId: response.ReferenceId,
+          message: response.message || "OTP sent on WhatsApp",
+        });
+      })
+      .catch((error) => {
+        console.error("There was a problem with the fetch operation:", error);
+        setData({ ...data, loading: false });
+      });
   };
 
   return (
@@ -134,9 +258,9 @@ export default function Signup({ CheckLogin }) {
             </div>
           </div>
         </div>
-        
+
         {/* Right side - Background image area (40% width) */}
-        <div 
+        <div
           className="flex-1 md:w-2/5 relative"
           style={{
             backgroundImage: 'url("/assets/background/bg-newSignin.webp")',
@@ -146,13 +270,13 @@ export default function Signup({ CheckLogin }) {
           }}
         >
           {/* Login form overlay */}
-          <div 
+          <div
             className="absolute inset-0 bg-white/30 flex flex-col justify-center items-center z-10 px-4 py-8 shadow-lg md:shadow-none"
             style={{
               boxShadow: "0px 4px 4px 0px #00000040"
             }}
           >
-          
+
           <h2 className="text-2xl font-bold text-gray-800 mb-8 z-20">Sign up</h2>
           <div className="w-full max-w-sm space-y-6 z-20">
             <div className="relative z-30">
@@ -160,54 +284,62 @@ export default function Signup({ CheckLogin }) {
                 type="text"
                 placeholder="Name"
                 value={data.name}
-                onChange={(e) =>
-                  setData({
-                    ...data,
-                    name: e.target.value,
-                  })
-                }
+                onChange={(e) => setData({ ...data, name: e.target.value })}
                 name="name"
                 className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
-                style={{
-                  boxShadow: "0px 4px 4px 0px #00000040"
-                }}
+                style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
               />
             </div>
-            <div className="relative z-30">
+            <div className="flex gap-2 relative z-30">
+              <select
+                value={data.countryCode}
+                onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                disabled={data.otpSent}
+                className="px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+              >
+                {COUNTRIES.map((c) => (
+                  <option key={`${c.code}-${c.name}`} value={c.code}>
+                    {c.flag} {c.code} {c.name}
+                  </option>
+                ))}
+              </select>
               <input
-                type="text"
-                placeholder="Phone number"
+                type="tel"
+                inputMode="numeric"
+                placeholder={`${country.digits} digits`}
                 value={data.phone}
-                onChange={(e) =>
-                  setData({
-                    ...data,
-                    phone: e.target.value,
-                  })
-                }
+                maxLength={country.digits}
+                onChange={(e) => setData({ ...data, phone: e.target.value.replace(/\D/g, "") })}
+                disabled={data.otpSent}
                 name="phone"
-                className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
-                style={{
-                  boxShadow: "0px 4px 4px 0px #00000040"
-                }}
+                className="flex-1 min-w-0 px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
               />
             </div>
+            {!isIndia(data.countryCode) && (
+              <div className="relative z-30">
+                <input
+                  type="email"
+                  placeholder="Email"
+                  value={data.email}
+                  onChange={(e) => setData({ ...data, email: e.target.value })}
+                  name="email"
+                  className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
+                  style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                />
+              </div>
+            )}
             {data.otpSent && (
               <div className="relative z-30">
                 <input
                   type="text"
                   placeholder="OTP"
                   value={data.Otp}
-                  onChange={(e) =>
-                    setData({
-                      ...data,
-                      Otp: e.target.value,
-                    })
-                  }
+                  onChange={(e) => setData({ ...data, Otp: e.target.value })}
                   name="otp"
                   className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent relative z-30"
-                  style={{
-                    boxShadow: "0px 4px 4px 0px #00000040"
-                  }}
+                  style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
                 />
               </div>
             )}
@@ -235,7 +367,7 @@ export default function Signup({ CheckLogin }) {
               </button>
             </div>
             <p className="text-center text-sm text-gray-600 mb-4 md:mb-0">
-              Already have an account? <span 
+              Already have an account? <span
                 className="text-red-800 font-semibold cursor-pointer hover:underline"
                 onClick={() => {
                   router.push('/login');

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -295,12 +295,12 @@ export default function Signup({ CheckLogin }) {
                 value={data.countryCode}
                 onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                 disabled={data.otpSent}
-                className="px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                className="w-28 px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
                 style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
               >
                 {COUNTRIES.map((c) => (
-                  <option key={`${c.code}-${c.name}`} value={c.code}>
-                    {c.flag} {c.code} {c.name}
+                  <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
+                    {c.flag} {c.code}
                   </option>
                 ))}
               </select>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,5 +1,5 @@
 import { processMobileNumber } from "@/utils/phoneNumber";
-import { COUNTRIES, getCountry, isIndia, detectCountryCode } from "@/utils/countries";
+import { COUNTRIES, getCountry, isIndia, isOther, isValidCustomCode, effectiveCountryCode, detectCountryCode } from "@/utils/countries";
 import { trimTitle } from "@/utils/seo";
 import { Spinner } from "flowbite-react";
 import Head from "next/head";
@@ -10,6 +10,7 @@ export default function Signup({ CheckLogin }) {
   const router = useRouter();
   const [data, setData] = useState({
     countryCode: "+91",
+    customCountryCode: "+",
     phone: "",
     name: "",
     email: "",
@@ -29,9 +30,14 @@ export default function Signup({ CheckLogin }) {
   }, []);
 
   const country = getCountry(data.countryCode);
+  const effectiveCC = effectiveCountryCode(data.countryCode, data.customCountryCode);
 
   const handleSignup = async () => {
-    if (isIndia(data.countryCode)) {
+    if (isOther(data.countryCode) && !isValidCustomCode(data.customCountryCode)) {
+      setData({ ...data, message: "Enter a valid country code (e.g. +49)" });
+      return;
+    }
+    if (isIndia(effectiveCC)) {
       // Existing Indian flow: single /enquiry call verifies OTP + creates record
       if (await processMobileNumber(data.phone)) {
         setData({ ...data, loading: true });
@@ -92,7 +98,7 @@ export default function Signup({ CheckLogin }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             phone: data.phone,
-            countryCode: data.countryCode,
+            countryCode: effectiveCC,
             otp: data.Otp,
             referenceId: data.ReferenceId,
           }),
@@ -136,7 +142,7 @@ export default function Signup({ CheckLogin }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             phone: data.phone,
-            countryCode: data.countryCode,
+            countryCode: effectiveCC,
             name: data.name,
             email: data.email,
             signupToken: verifyRes.signupToken,
@@ -175,7 +181,11 @@ export default function Signup({ CheckLogin }) {
   };
 
   const SendOTP = async () => {
-    if (isIndia(data.countryCode)) {
+    if (isOther(data.countryCode) && !isValidCustomCode(data.customCountryCode)) {
+      setData({ ...data, message: "Enter a valid country code (e.g. +49)" });
+      return;
+    }
+    if (isIndia(effectiveCC)) {
       if (await processMobileNumber(data.phone)) {
         setData({ ...data, loading: true });
         fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/otp`, {
@@ -212,7 +222,7 @@ export default function Signup({ CheckLogin }) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         phone: data.phone,
-        countryCode: data.countryCode,
+        countryCode: effectiveCC,
       }),
     })
       .then((r) => r.json())
@@ -295,12 +305,12 @@ export default function Signup({ CheckLogin }) {
                 value={data.countryCode}
                 onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
                 disabled={data.otpSent}
-                className="w-28 px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                className="w-[120px] px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
                 style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
               >
                 {COUNTRIES.map((c) => (
                   <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                    {c.flag} {c.code}
+                    {c.flag} {isOther(c.code) ? "Other" : c.code}
                   </option>
                 ))}
               </select>
@@ -317,7 +327,25 @@ export default function Signup({ CheckLogin }) {
                 style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
               />
             </div>
-            {!isIndia(data.countryCode) && (
+            {isOther(data.countryCode) && (
+              <div className="relative z-30">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="+49"
+                  value={data.customCountryCode}
+                  maxLength={5}
+                  onChange={(e) => {
+                    const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                    setData({ ...data, customCountryCode: "+" + digits });
+                  }}
+                  disabled={data.otpSent}
+                  className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                  style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                />
+              </div>
+            )}
+            {!isIndia(effectiveCC) && (
               <div className="relative z-30">
                 <input
                   type="email"

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -337,7 +337,12 @@ export default function Signup({ CheckLogin }) {
                   maxLength={5}
                   onChange={(e) => {
                     const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                    setData({ ...data, customCountryCode: "+" + digits });
+                    const newCustom = "+" + digits;
+                    if (newCustom === "+91") {
+                      setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                    } else {
+                      setData({ ...data, customCountryCode: newCustom });
+                    }
                   }}
                   disabled={data.otpSent}
                   className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -301,19 +301,56 @@ export default function Signup({ CheckLogin }) {
               />
             </div>
             <div className="flex gap-2 relative z-30">
-              <select
-                value={data.countryCode}
-                onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
-                disabled={data.otpSent}
-                className="w-[120px] px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
-                style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
-              >
-                {COUNTRIES.map((c) => (
-                  <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
-                    {c.flag} {isOther(c.code) ? "Other" : c.code}
-                  </option>
-                ))}
-              </select>
+              {isOther(data.countryCode) ? (
+                <div
+                  className="w-[120px] flex items-center px-2 rounded-lg border border-gray-300 bg-white focus-within:ring-2 focus-within:ring-red-600"
+                  style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                >
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="+49"
+                    value={data.customCountryCode}
+                    maxLength={5}
+                    autoFocus
+                    onChange={(e) => {
+                      const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
+                      const newCustom = "+" + digits;
+                      if (newCustom === "+91") {
+                        setData({ ...data, countryCode: "+91", customCountryCode: "+" });
+                      } else {
+                        setData({ ...data, customCountryCode: newCustom });
+                      }
+                    }}
+                    disabled={data.otpSent}
+                    className="flex-1 min-w-0 py-3 bg-transparent border-0 focus:outline-none focus:ring-0"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setData({ ...data, countryCode: "+91", customCountryCode: "+" })}
+                    disabled={data.otpSent}
+                    title="Back to country list"
+                    aria-label="Back to country list"
+                    className="text-gray-500 hover:text-gray-800 text-lg leading-none px-1"
+                  >
+                    ×
+                  </button>
+                </div>
+              ) : (
+                <select
+                  value={data.countryCode}
+                  onChange={(e) => setData({ ...data, countryCode: e.target.value, phone: "" })}
+                  disabled={data.otpSent}
+                  className="w-[120px] px-3 py-3 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-red-600"
+                  style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
+                >
+                  {COUNTRIES.map((c) => (
+                    <option key={`${c.code}-${c.name}`} value={c.code} title={c.name}>
+                      {c.flag} {isOther(c.code) ? "Other" : c.code}
+                    </option>
+                  ))}
+                </select>
+              )}
               <input
                 type="tel"
                 inputMode="numeric"
@@ -327,29 +364,6 @@ export default function Signup({ CheckLogin }) {
                 style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
               />
             </div>
-            {isOther(data.countryCode) && (
-              <div className="relative z-30">
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  placeholder="+49"
-                  value={data.customCountryCode}
-                  maxLength={5}
-                  onChange={(e) => {
-                    const digits = e.target.value.replace(/\D/g, "").slice(0, 4);
-                    const newCustom = "+" + digits;
-                    if (newCustom === "+91") {
-                      setData({ ...data, countryCode: "+91", customCountryCode: "+" });
-                    } else {
-                      setData({ ...data, customCountryCode: newCustom });
-                    }
-                  }}
-                  disabled={data.otpSent}
-                  className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
-                  style={{ boxShadow: "0px 4px 4px 0px #00000040" }}
-                />
-              </div>
-            )}
             {!isIndia(effectiveCC) && (
               <div className="relative z-30">
                 <input

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/* NProgress bar — Wedsy brand color */
+#nprogress .bar {
+  background: #840032 !important;
+  height: 3px !important;
+}
+#nprogress .peg {
+  box-shadow: 0 0 10px #840032, 0 0 5px #840032 !important;
+}
+
 /* Dream Avenue Font */
 @font-face {
   font-family: "Dream Avenue";

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -246,6 +246,11 @@ body {
 
 html,
 body {
+  max-width: 100vw;
   overflow-x: hidden;
   scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
 }

--- a/utils/countries.js
+++ b/utils/countries.js
@@ -1,0 +1,36 @@
+export const COUNTRIES = [
+  { code: "+91", name: "India", flag: "🇮🇳", digits: 10 },
+  { code: "+1", name: "USA/Canada", flag: "🇺🇸", digits: 10 },
+  { code: "+44", name: "UK", flag: "🇬🇧", digits: 10 },
+  { code: "+971", name: "UAE", flag: "🇦🇪", digits: 9 },
+  { code: "+65", name: "Singapore", flag: "🇸🇬", digits: 8 },
+  { code: "+61", name: "Australia", flag: "🇦🇺", digits: 9 },
+];
+
+const ISO_TO_CODE = {
+  IN: "+91",
+  US: "+1",
+  CA: "+1",
+  GB: "+44",
+  AE: "+971",
+  SG: "+65",
+  AU: "+61",
+};
+
+export function getCountry(code) {
+  return COUNTRIES.find((c) => c.code === code) || COUNTRIES[0];
+}
+
+export function isIndia(code) {
+  return code === "+91";
+}
+
+export async function detectCountryCode() {
+  try {
+    const res = await fetch("https://ipapi.co/json/");
+    const data = await res.json();
+    return ISO_TO_CODE[data?.country_code] || "+91";
+  } catch {
+    return "+91";
+  }
+}

--- a/utils/countries.js
+++ b/utils/countries.js
@@ -1,3 +1,5 @@
+export const OTHER_CODE = "other";
+
 export const COUNTRIES = [
   { code: "+91", name: "India", flag: "🇮🇳", digits: 10 },
   { code: "+1", name: "USA/Canada", flag: "🇺🇸", digits: 10 },
@@ -5,7 +7,20 @@ export const COUNTRIES = [
   { code: "+971", name: "UAE", flag: "🇦🇪", digits: 9 },
   { code: "+65", name: "Singapore", flag: "🇸🇬", digits: 8 },
   { code: "+61", name: "Australia", flag: "🇦🇺", digits: 9 },
+  { code: OTHER_CODE, name: "Other", flag: "🌍", digits: 10 },
 ];
+
+export function isOther(code) {
+  return code === OTHER_CODE;
+}
+
+export function isValidCustomCode(code) {
+  return /^\+\d{1,4}$/.test(code || "");
+}
+
+export function effectiveCountryCode(selected, custom) {
+  return selected === OTHER_CODE ? custom : selected;
+}
 
 const ISO_TO_CODE = {
   IN: "+91",


### PR DESCRIPTION
## Summary

Closes Sub-phase 1.4.C, the final piece of Phase 1 frontend wiring.

The Regenerate button on the new Profile dashboard now calls the real Anthropic regenerate endpoint (live since Sub-phase 1.2, deployed 9 May). Replaces the setTimeout mock from PR #15.

Plus a small product-decision implementation: when the AI returns empty suggestions AND the event's wedding date is in the past, render a warm 'celebration complete' card with a 'Create a new event →' CTA. Handles the real edge case where users have old events and the AI correctly returns nothing.

## What's wired

- `POST /event/:eventId/wedding-timeline/regenerate` — real Anthropic call
- Loading state (spinning glyph, REGENERATING… label, disabled button)
- Error state (mapped error codes to user-facing messages)
- Success → timeline refetch
- Empty-suggestions-on-past-event → friendly card + create-new-event CTA

## What's NOT in this PR

- Suggestion-application UI (Add/Adjust/Remove cards with checkboxes for users to approve AI changes). The backend returns suggestions; the frontend just refetches the timeline. Full suggestion-application UI is a Phase 1.6 sub-phase.
- Rate limiting / cost controls (no caps on regenerate calls). Defer to future sub-phase once usage data exists.
- Stats grid + Inspiration card real data (still mocked).

## Verification

- Build clean: /profile route bundle 8.17 kB / 220 kB (was 7.73 kB; +0.44 kB)
- Real POST verified against prod.server.wedsy.in with Rohaan's actual event:
  - Status: 200
  - Response: empty add/adjust/remove arrays (correct AI behavior for past event)
- Past-event card rendered visually
- Create-new-event button routed to /profile?state=empty1 correctly

## Notion

Phase 1 Build Log: https://www.notion.so/35972ef954ed81f79687d561bfc9bcd0