### PR TITLE
feat(profile): three-rail desktop layout shell (Phase 1.5.A)

### DIFF
--- a/components/profile/DesktopLayout.js
+++ b/components/profile/DesktopLayout.js
@@ -1,0 +1,130 @@
+import {
+  Bookmark,
+  CalendarRange,
+  ChevronDown,
+  CreditCard,
+  Hammer,
+  Heart,
+  LayoutDashboard,
+  ListChecks,
+  LogOut,
+  MessageCircle,
+  Package,
+  UserCircle,
+} from "lucide-react";
+import Link from "next/link";
+
+function deriveMonogram(event) {
+  if (!event?.name) return "W";
+  const initials = event.name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() || "")
+    .join("");
+  return initials || "W";
+}
+
+function deriveEventMeta(event, events) {
+  const count = events?.length || 1;
+  const lastDay = event?.eventDays?.[event.eventDays.length - 1];
+  const countLabel = `${count} event${count === 1 ? "" : "s"}`;
+  if (!lastDay?.date) return countLabel;
+  const d = new Date(lastDay.date);
+  const month = d.toLocaleString("en-GB", { month: "short" });
+  return `${d.getDate()} ${month} ${d.getFullYear()} · ${countLabel}`;
+}
+
+const NAV_ICON_PROPS = { size: 16, strokeWidth: 1.5 };
+
+function NavRow({ icon: Icon, label, active = false, badge }) {
+  const base = "flex items-center justify-between gap-3 px-3 py-2 text-[13px] transition-colors";
+  const tone = active
+    ? "bg-wedsy-rose-50 text-wedsy-ink font-medium"
+    : "text-wedsy-ink-2 hover:bg-wedsy-rose-50/40";
+  return (
+    <Link href="#" className={`${base} ${tone}`}>
+      <span className="flex items-center gap-3">
+        <Icon {...NAV_ICON_PROPS} className="text-wedsy-rose-600" />
+        {label}
+      </span>
+      {badge && (
+        <span className="text-[9px] tracking-[1px] uppercase font-medium bg-wedsy-rose-600 text-white px-1.5 py-0.5">
+          {badge}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+function SectionLabel({ children }) {
+  return (
+    <p className="text-[10px] tracking-[2px] uppercase font-medium text-wedsy-ink-3 px-3 mt-5 mb-2">
+      {children}
+    </p>
+  );
+}
+
+function PlaceholderCard({ eyebrow, label }) {
+  return (
+    <div className="bg-white border border-wedsy-rose-100 rounded p-6">
+      <p className="text-[10px] tracking-[2px] uppercase font-medium text-wedsy-rose-600">{eyebrow}</p>
+      <p className="font-serif text-[16px] text-wedsy-ink mt-2">{label}</p>
+      <p className="font-serif italic text-[12px] text-wedsy-ink-3 mt-1">(coming in 1.5.E)</p>
+    </div>
+  );
+}
+
+export default function DesktopLayout({ event, events, children }) {
+  const monogram = deriveMonogram(event);
+  const eventMeta = deriveEventMeta(event, events);
+
+  return (
+    <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)_320px] lg:min-h-screen">
+      <aside className="hidden lg:flex lg:flex-col bg-wedsy-ivory-2 px-6 py-9">
+        <div className="text-center pb-4 border-b border-wedsy-rose-100">
+          <span className="font-serif text-[36px] tracking-[4px] text-wedsy-burgundy">{monogram}</span>
+        </div>
+        <div className="py-5 border-b border-wedsy-rose-100 cursor-pointer">
+          <div className="flex items-center justify-between">
+            <div className="min-w-0">
+              <div className="font-serif text-[19px] leading-tight text-wedsy-ink truncate">
+                {event?.name || "Your wedding"}
+              </div>
+              <div className="text-[11px] text-wedsy-ink-3 mt-1">{eventMeta}</div>
+            </div>
+            <ChevronDown size={14} className="text-wedsy-rose-600 shrink-0 ml-2" />
+          </div>
+        </div>
+        <nav className="flex-1 mt-2">
+          <SectionLabel>This wedding</SectionLabel>
+          <NavRow icon={LayoutDashboard} label="Dashboard" active />
+          <NavRow icon={CalendarRange} label="Event days" />
+          <NavRow icon={ListChecks} label="Timeline" />
+          <SectionLabel>Activity</SectionLabel>
+          <NavRow icon={Package} label="Orders" />
+          <NavRow icon={CreditCard} label="Payments" />
+          <NavRow icon={Hammer} label="My bids" badge="3 NEW" />
+          <NavRow icon={Heart} label="Wishlist" />
+          <SectionLabel>Discover</SectionLabel>
+          <NavRow icon={Bookmark} label="Inspiration" />
+          <NavRow icon={MessageCircle} label="Support" />
+        </nav>
+        <div className="pt-4 border-t border-wedsy-rose-100 mt-2">
+          <NavRow icon={UserCircle} label="Account" />
+          <NavRow icon={LogOut} label="Sign out" />
+        </div>
+      </aside>
+
+      <main className="lg:py-12 lg:px-14">{children}</main>
+
+      <aside className="hidden lg:block bg-wedsy-ivory border-l border-wedsy-rose-100 px-7 py-14">
+        <div className="space-y-6">
+          <PlaceholderCard eyebrow="NEXT UP" label="Next-up callout" />
+          <PlaceholderCard eyebrow="INSPIRATION" label="Inspiration card" />
+          <PlaceholderCard eyebrow="THIS WEEK" label="This week" />
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/hooks/useProfileData.js
+++ b/hooks/useProfileData.js
@@ -13,6 +13,7 @@ function pickPrimaryEvent(events) {
 
 export default function useProfileData({ token }) {
   const [event, setEvent] = useState(null);
+  const [events, setEvents] = useState([]);
   const [eventLoading, setEventLoading] = useState(true);
   const [eventError, setEventError] = useState(null);
   const [milestones, setMilestones] = useState([]);
@@ -57,15 +58,17 @@ export default function useProfileData({ token }) {
         setEventLoading(true);
         setEventError(null);
       }
-      const { data: events, error } = await fetchEvents(token);
+      const { data: eventList, error } = await fetchEvents(token);
       if (!isMountedRef.current) return;
       if (error) {
         setEventError(error);
         setEvent(null);
+        setEvents([]);
         setEventLoading(false);
         return;
       }
-      const primary = pickPrimaryEvent(events);
+      setEvents(eventList || []);
+      const primary = pickPrimaryEvent(eventList);
       setEvent(primary);
       setEventLoading(false);
       if (primary?._id) {
@@ -84,6 +87,7 @@ export default function useProfileData({ token }) {
 
   return {
     event,
+    events,
     eventLoading,
     eventError,
     milestones,

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,4 +1,5 @@
 import AccountList from "@/components/profile/AccountList";
+import DesktopLayout from "@/components/profile/DesktopLayout";
 import EmptyStateStep1 from "@/components/profile/EmptyStateStep1";
 import EmptyStateStep2 from "@/components/profile/EmptyStateStep2";
 import EventDaysCarousel from "@/components/profile/EventDaysCarousel";
@@ -77,6 +78,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
 
   const {
     event,
+    events,
     eventLoading,
     eventError,
     milestones,
@@ -114,7 +116,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
       <Head>
         <title>Profile · Wedsy</title>
       </Head>
-      <div className="wedsy-screen-container">
+      <div className="wedsy-screen-container wedsy-desktop-container">
         {eventLoading ? (
           <p className="wedsy-subtitle" style={{ padding: "60px 24px", textAlign: "center" }}>Loading…</p>
         ) : eventError ? (
@@ -131,7 +133,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             onComplete={(data) => console.log("Mock complete event days:", data)}
           />
         ) : (
-          <>
+          <DesktopLayout event={event} events={events}>
             <ProfileHero
               coupleName={deriveCoupleName(event)}
               weddingDate={deriveWeddingDate(event)}
@@ -167,7 +169,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
               items={MOCK_ACCOUNT_ITEMS}
               onSignOut={() => console.log("Mock sign out")}
             />
-          </>
+          </DesktopLayout>
         )}
       </div>
     </>

--- a/styles/wedsy-design-system.css
+++ b/styles/wedsy-design-system.css
@@ -53,3 +53,9 @@
   opacity: 0.3;
   border: 0;
 }
+
+@media (min-width: 1024px) {
+  .wedsy-desktop-container {
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Summary

First sub-phase of Phase 1.5 (desktop layout). Establishes the three-rail page shell at desktop widths (>=1024px). Mobile layout below that breakpoint is completely unchanged.

## What's in this PR

- New `components/profile/DesktopLayout.js` — three-rail grid with left rail (nav), center workspace (existing content), right rail (placeholders for 1.5.E)
- `hooks/useProfileData.js` — exposes events array alongside the existing primary event
- `pages/profile.js` — wraps populated branch in DesktopLayout
- `styles/wedsy-design-system.css` — new .wedsy-desktop-container utility that escapes the 480px mobile cap at lg+ breakpoint

## What's NOT in this PR

- Horizontal hero banner (Phase 1.5.B)
- Multi-event switcher functionality (Phase 1.5.B)
- Legacy chrome hiding (Phase 1.5.B)
- Timeline canvas (Phase 1.5.C)
- Right rail real content (Phase 1.5.E)

## Known interim visual state

At desktop width, the center workspace currently shows the mobile-designed components stretched into a wider container. The right rail shows placeholders that say '(coming in 1.5.E)'. This is expected — each later sub-phase replaces a section with its desktop-appropriate version.

## Verification

- Build clean: /profile route bundle 9.5 kB / 221 kB (was 8.17 kB; +1.33 kB for DesktopLayout + lucide icons)
- Desktop view (>=1024px): three rails render with correct content
- Mobile view (<1024px): rails hidden completely, existing mobile layout renders unchanged — no regression

## Notion

Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a