### PR TITLE
feat(profile): hide legacy site chrome on /profile desktop (Phase 1.5.B.1)

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -281,7 +281,7 @@ function App({ Component, pageProps }) {
       )}
 
         <div className="flex flex-col min-h-screen">
-          <header className="contents">
+          <header className={router.pathname === "/profile" ? "contents lg:hidden" : "contents"}>
             <Header userLoggedIn={!logIn} user={user} Logout={Logout} />
           </header>
           <LoginModal openLoginModal={openLoginModal} setOpenLoginModal={setOpenLoginModal} user={user} logIn={logIn} setLogIn={setLogIn} CheckLogin={CheckLogin} />
@@ -317,7 +317,7 @@ function App({ Component, pageProps }) {
               </motion.div>
             </AnimatePresence>
           </main>
-          <footer className="contents">
+          <footer className={router.pathname === "/profile" ? "contents lg:hidden" : "contents"}>
             <Footer />
             <MobileStickyFooter />
           </footer>


### PR DESCRIPTION
## Summary

First sub-sub-phase of 1.5.B. Hides the legacy wedsy.in site header and footer on /profile at desktop breakpoints (>=1024px). Mobile /profile and all other routes are unchanged.

## What's in this PR

- `pages/_app.js` — two inline className conditionals on the existing header/footer wrappers (+2/-2 lines)

## What's NOT in this PR

- Horizontal hero banner (Phase 1.5.B.3)
- Multi-event switcher functionality (Phase 1.5.B.2)
- BROWSE section nav rows for Wedding Store + Makeup Artist (Phase 1.5.B.3)

## Approach

Server-safe conditional rendering using Tailwind responsive class composition. On /profile, header/footer wrappers get className "contents lg:hidden"; on other routes they get "contents". The lg variant wins at desktop via CSS source order. No SSR mismatch risk, no React state, no window check.

Legacy components are wrapped, not unmounted — internal state is preserved.

## Verification

- Build clean: /profile route bundle unchanged at 9.5 kB (change is in _app.js)
- Desktop /profile: chrome hidden ✓
- Mobile /profile: chrome visible ✓
- Other routes (/wedding-store, /): chrome visible at all widths ✓

## Notion

Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a (Decisions 10, 12, 13)