### PR TITLE
feat(profile): multi-event switcher dropdown (Phase 1.5.B.2)

### DIFF
--- a/components/profile/DesktopLayout.js
+++ b/components/profile/DesktopLayout.js
@@ -1,7 +1,7 @@
+import EventSwitcherDropdown from "@/components/profile/EventSwitcherDropdown";
 import {
   Bookmark,
   CalendarRange,
-  ChevronDown,
   CreditCard,
   Hammer,
   Heart,
@@ -23,16 +23,6 @@ function deriveMonogram(event) {
     .map((w) => w[0]?.toUpperCase() || "")
     .join("");
   return initials || "W";
-}
-
-function deriveEventMeta(event, events) {
-  const count = events?.length || 1;
-  const lastDay = event?.eventDays?.[event.eventDays.length - 1];
-  const countLabel = `${count} event${count === 1 ? "" : "s"}`;
-  if (!lastDay?.date) return countLabel;
-  const d = new Date(lastDay.date);
-  const month = d.toLocaleString("en-GB", { month: "short" });
-  return `${d.getDate()} ${month} ${d.getFullYear()} · ${countLabel}`;
 }
 
 const NAV_ICON_PROPS = { size: 16, strokeWidth: 1.5 };
@@ -75,9 +65,15 @@ function PlaceholderCard({ eyebrow, label }) {
   );
 }
 
-export default function DesktopLayout({ event, events, children }) {
+export default function DesktopLayout({
+  event,
+  events,
+  onSwitchEvent,
+  onCreateNewEvent,
+  onManageAllEvents,
+  children,
+}) {
   const monogram = deriveMonogram(event);
-  const eventMeta = deriveEventMeta(event, events);
 
   return (
     <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)_320px] lg:min-h-screen">
@@ -85,17 +81,13 @@ export default function DesktopLayout({ event, events, children }) {
         <div className="text-center pb-4 border-b border-wedsy-rose-100">
           <span className="font-serif text-[36px] tracking-[4px] text-wedsy-burgundy">{monogram}</span>
         </div>
-        <div className="py-5 border-b border-wedsy-rose-100 cursor-pointer">
-          <div className="flex items-center justify-between">
-            <div className="min-w-0">
-              <div className="font-serif text-[19px] leading-tight text-wedsy-ink truncate">
-                {event?.name || "Your wedding"}
-              </div>
-              <div className="text-[11px] text-wedsy-ink-3 mt-1">{eventMeta}</div>
-            </div>
-            <ChevronDown size={14} className="text-wedsy-rose-600 shrink-0 ml-2" />
-          </div>
-        </div>
+        <EventSwitcherDropdown
+          event={event}
+          events={events}
+          onSwitch={onSwitchEvent}
+          onCreateNew={onCreateNewEvent}
+          onManageAll={onManageAllEvents}
+        />
         <nav className="flex-1 mt-2">
           <SectionLabel>This wedding</SectionLabel>
           <NavRow icon={LayoutDashboard} label="Dashboard" active />

--- a/components/profile/EventSwitcherDropdown.js
+++ b/components/profile/EventSwitcherDropdown.js
@@ -1,0 +1,121 @@
+import { ChevronDown, Plus, Settings } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+function formatWeddingDate(event) {
+  const lastDay = event?.eventDays?.[event.eventDays.length - 1];
+  if (!lastDay?.date) return null;
+  const d = new Date(lastDay.date);
+  return `${d.getDate()} ${d.toLocaleString("en-GB", { month: "short" })} ${d.getFullYear()}`;
+}
+
+function deriveTriggerMeta(event, events) {
+  const count = events?.length || 1;
+  const countLabel = `${count} event${count === 1 ? "" : "s"}`;
+  const dateLabel = formatWeddingDate(event);
+  return dateLabel ? `${dateLabel} · ${countLabel}` : countLabel;
+}
+
+const sortByCreatedDesc = (events) =>
+  [...(events || [])].sort((a, b) => (b.createdAt ? new Date(b.createdAt).getTime() : 0) - (a.createdAt ? new Date(a.createdAt).getTime() : 0));
+
+export default function EventSwitcherDropdown({ event, events, onSwitch, onCreateNew, onManageAll }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const isMulti = (events?.length || 0) > 1;
+  const triggerMeta = deriveTriggerMeta(event, events);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleClickOutside = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setIsOpen(false);
+    };
+    const handleEsc = (e) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEsc);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEsc);
+    };
+  }, [isOpen]);
+
+  if (!isMulti) {
+    return (
+      <div className="py-5 border-b border-wedsy-rose-100">
+        <div className="font-serif text-[19px] leading-tight text-wedsy-ink truncate">{event?.name || "Your wedding"}</div>
+        <div className="text-[11px] text-wedsy-ink-3 mt-1">{triggerMeta}</div>
+      </div>
+    );
+  }
+
+  const sortedEvents = sortByCreatedDesc(events);
+
+  return (
+    <div ref={wrapperRef} className="relative py-5 border-b border-wedsy-rose-100">
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        className="w-full flex items-center justify-between text-left"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <div className="min-w-0">
+          <div className="font-serif text-[19px] leading-tight text-wedsy-ink truncate">
+            {event?.name || "Your wedding"}
+          </div>
+          <div className="text-[11px] text-wedsy-ink-3 mt-1">{triggerMeta}</div>
+        </div>
+        <ChevronDown
+          size={14}
+          className={`text-wedsy-rose-600 shrink-0 ml-2 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          role="listbox"
+          className="absolute top-full left-0 mt-2 w-[320px] bg-white border border-wedsy-rose-100 rounded z-50"
+          style={{ boxShadow: "0 4px 24px rgba(122,32,24,0.06)" }}
+        >
+          <ul className="py-2">
+            {sortedEvents.map((e) => {
+              const isCurrent = e._id === event?._id;
+              return (
+                <li key={e._id}>
+                  <button
+                    type="button"
+                    onClick={() => { setIsOpen(false); if (!isCurrent) onSwitch(e._id); }}
+                    className={`w-full flex items-start gap-3 px-4 py-3 text-left transition-colors ${isCurrent ? "bg-wedsy-rose-50/40" : "hover:bg-wedsy-rose-50/40"}`}
+                  >
+                    <span className={`mt-2 h-2 w-2 rounded-full shrink-0 ${isCurrent ? "bg-wedsy-rose-600" : "border border-wedsy-ink-3"}`} />
+                    <span className="flex-1 min-w-0">
+                      <span className="block font-serif text-[16px] text-wedsy-ink truncate">{e.name || "Your wedding"}</span>
+                      <span className="block text-[11px] text-wedsy-ink-3 mt-1">{formatWeddingDate(e) || "No date set"}</span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            type="button"
+            onClick={() => { setIsOpen(false); onCreateNew && onCreateNew(); }}
+            className="w-full flex items-center gap-2 px-4 py-3 text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 hover:bg-wedsy-rose-50/40 text-left border-t border-wedsy-rose-100"
+          >
+            <Plus size={14} strokeWidth={2} />
+            Create a new event
+          </button>
+          <button
+            type="button"
+            onClick={() => { setIsOpen(false); onManageAll && onManageAll(); }}
+            className="w-full flex items-center gap-2 px-4 py-3 text-[11px] tracking-[2px] uppercase font-medium text-wedsy-ink-3 hover:bg-wedsy-rose-50/40 text-left border-t border-wedsy-rose-100"
+          >
+            <Settings size={14} strokeWidth={2} />
+            All events
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/useProfileData.js
+++ b/hooks/useProfileData.js
@@ -11,7 +11,7 @@ function pickPrimaryEvent(events) {
   return sorted[0];
 }
 
-export default function useProfileData({ token }) {
+export default function useProfileData({ token, selectedEventId }) {
   const [event, setEvent] = useState(null);
   const [events, setEvents] = useState([]);
   const [eventLoading, setEventLoading] = useState(true);
@@ -68,17 +68,21 @@ export default function useProfileData({ token }) {
         return;
       }
       setEvents(eventList || []);
-      const primary = pickPrimaryEvent(eventList);
-      setEvent(primary);
+      let chosen = null;
+      if (selectedEventId && Array.isArray(eventList)) {
+        chosen = eventList.find((e) => e._id === selectedEventId) || null;
+      }
+      if (!chosen) chosen = pickPrimaryEvent(eventList);
+      setEvent(chosen);
       setEventLoading(false);
-      if (primary?._id) {
-        loadMilestones(primary._id);
+      if (chosen?._id) {
+        loadMilestones(chosen._id);
       } else {
         setMilestones([]);
       }
     };
     loadAll();
-  }, [token, loadMilestones]);
+  }, [token, loadMilestones, selectedEventId]);
 
   const refetchMilestones = useCallback(() => {
     if (event?._id) return loadMilestones(event._id);

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -65,6 +65,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
   const [regenerating, setRegenerating] = useState(false);
   const [regenerateError, setRegenerateError] = useState(null);
   const [regenerateResult, setRegenerateResult] = useState(null);
+  const [selectedEventId, setSelectedEventId] = useState(null);
 
   useEffect(() => {
     CheckLogin();
@@ -76,6 +77,16 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     }
   }, []);
 
+  useEffect(() => {
+    if (!router.isReady) return;
+    const urlId = typeof router.query.eventId === "string" ? router.query.eventId : "";
+    try {
+      const id = urlId || localStorage.getItem("wedsy.selectedEventId");
+      if (id) setSelectedEventId(id);
+      if (urlId) localStorage.setItem("wedsy.selectedEventId", urlId);
+    } catch {}
+  }, [router.isReady, router.query.eventId]);
+
   const {
     event,
     events,
@@ -85,7 +96,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     milestonesLoading,
     milestonesError,
     refetchMilestones,
-  } = useProfileData({ token });
+  } = useProfileData({ token, selectedEventId });
 
   if (!user?.name) {
     return (
@@ -110,6 +121,8 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
   const isEventPast = weddingDate ? new Date(weddingDate) < new Date() : false;
   const showPastEventCard = isEventPast && !!regenerateResult && !regenerateResult.add?.length && !regenerateResult.adjust?.length && !regenerateResult.remove?.length;
   const handleCreateNewEvent = () => router.push("/profile?state=empty1");
+  const handleSwitchEvent = (eventId) => router.push({ pathname: "/profile", query: { eventId } }, undefined, { shallow: true });
+  const handleManageAll = () => router.push("/event");
 
   return (
     <>
@@ -133,7 +146,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             onComplete={(data) => console.log("Mock complete event days:", data)}
           />
         ) : (
-          <DesktopLayout event={event} events={events}>
+          <DesktopLayout event={event} events={events} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll}>
             <ProfileHero
               coupleName={deriveCoupleName(event)}
               weddingDate={deriveWeddingDate(event)}


### PR DESCRIPTION
## Summary

Second sub-sub-phase of 1.5.B. Stateful event switcher dropdown in /profile left rail (desktop). Lets multi-event users switch active event. Single-event users see no UI change. Fixes the multi-event hiding bug from production as a side effect.

## What's in this PR

- New: `components/profile/EventSwitcherDropdown.js` (121 lines) — self-contained component with trigger row + dropdown panel
- `hooks/useProfileData.js` — accepts `selectedEventId` param, falls back to `pickPrimaryEvent`
- `pages/profile.js` — new selectedEventId state, URL+localStorage sync useEffect, switch/manage handlers
- `components/profile/DesktopLayout.js` — replaces static event-switcher block with EventSwitcherDropdown

## What's NOT in this PR

- Horizontal hero banner (Phase 1.5.B.3)
- BROWSE section nav rows for Wedding Store + Makeup Artist (Phase 1.5.B.3)
- Center workspace content redesigns (Phase 1.5.C onwards)

## Behavior summary

| Scenario | Behavior |
|---|---|
| Single-event user, desktop /profile | Plain event-name row, no chevron, no clickable |
| Multi-event user, desktop /profile | Chevron on row, click opens dropdown |
| Click outside dropdown / press ESC | Dropdown closes |
| Click another event in dropdown | URL updates to ?eventId=, localStorage updates, dashboard refetches |
| Hard-refresh /profile?eventId=ABC | Loads event ABC |
| Hard-refresh bare /profile | Loads event from localStorage (or pickPrimaryEvent fallback) |
| Mobile /profile (<1024px) | No dropdown UI, mobile layout unchanged |

## Verification

- Build clean: /profile route bundle 10.5 kB / 222 kB (was 9.5 kB; +1 kB for dropdown component + state management)
- All 13 visual/behavior checks passed (single-event affordance, dropdown open/close via 3 mechanisms, URL sync, localStorage persist, hard-refresh fidelity, mobile no-regression, CTA routing)
- Production multi-event hiding bug now fixed for users with >1 events

## Notion

Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a (Decisions 6-9)