### PR TITLE
feat(profile): horizontal hero banner + BROWSE nav section (Phase 1.5.B.3)

### DIFF
--- a/components/profile/DesktopLayout.js
+++ b/components/profile/DesktopLayout.js
@@ -10,6 +10,8 @@ import {
   LogOut,
   MessageCircle,
   Package,
+  Sparkles,
+  Store,
   UserCircle,
 } from "lucide-react";
 import Link from "next/link";
@@ -27,13 +29,13 @@ function deriveMonogram(event) {
 
 const NAV_ICON_PROPS = { size: 16, strokeWidth: 1.5 };
 
-function NavRow({ icon: Icon, label, active = false, badge }) {
+function NavRow({ icon: Icon, label, active = false, badge, href }) {
   const base = "flex items-center justify-between gap-3 px-3 py-2 text-[13px] transition-colors";
   const tone = active
     ? "bg-wedsy-rose-50 text-wedsy-ink font-medium"
     : "text-wedsy-ink-2 hover:bg-wedsy-rose-50/40";
-  return (
-    <Link href="#" className={`${base} ${tone}`}>
+  const content = (
+    <>
       <span className="flex items-center gap-3">
         <Icon {...NAV_ICON_PROPS} className="text-wedsy-rose-600" />
         {label}
@@ -43,8 +45,9 @@ function NavRow({ icon: Icon, label, active = false, badge }) {
           {badge}
         </span>
       )}
-    </Link>
+    </>
   );
+  return <Link href={href || "#"} className={`${base} ${tone}`}>{content}</Link>;
 }
 
 function SectionLabel({ children }) {
@@ -101,6 +104,9 @@ export default function DesktopLayout({
           <SectionLabel>Discover</SectionLabel>
           <NavRow icon={Bookmark} label="Inspiration" />
           <NavRow icon={MessageCircle} label="Support" />
+          <SectionLabel>Browse</SectionLabel>
+          <NavRow icon={Store} label="Wedding Store" href="/wedding-store" />
+          <NavRow icon={Sparkles} label="Makeup & Beauty" href="/makeup-and-beauty" />
         </nav>
         <div className="pt-4 border-t border-wedsy-rose-100 mt-2">
           <NavRow icon={UserCircle} label="Account" />

--- a/components/profile/ProfileHero.js
+++ b/components/profile/ProfileHero.js
@@ -6,7 +6,7 @@ export default function ProfileHero({
   eventDayCount = 1,
   eventDayNames = [],
 }) {
-  const { formattedDate, countdownText } = useMemo(() => {
+  const { formattedDate, countdownText, variant, daysAbs, rightEyebrow, rightCaption } = useMemo(() => {
     const ordinalSuffix = (day) => {
       if (day >= 11 && day <= 13) return "th";
       const last = day % 10;
@@ -19,16 +19,16 @@ export default function ProfileHero({
     const wedding = new Date(weddingDate);
     const today = new Date();
     const diff = Math.ceil((wedding - today) / 86400000);
+    const v = diff > 0 ? "future" : diff === 0 ? "today" : "past";
+    const abs = Math.abs(diff);
 
     let text;
-    if (diff > 0) {
-      text = `${diff} ${diff === 1 ? "day" : "days"} to your wedding`;
-    } else if (diff === 0) {
-      text = "Today is your wedding day";
-    } else {
-      const past = Math.abs(diff);
-      text = `${past} ${past === 1 ? "day" : "days"} since your wedding`;
-    }
+    if (v === "future") text = `${diff} ${diff === 1 ? "day" : "days"} to your wedding`;
+    else if (v === "today") text = "Today is your wedding day";
+    else text = `${abs} ${abs === 1 ? "day" : "days"} since your wedding`;
+
+    const eyebrow = v === "future" ? "COUNTDOWN" : v === "today" ? "TODAY" : "SINCE";
+    const caption = v === "future" ? "days to your wedding" : v === "today" ? "your wedding day" : "days since your wedding";
 
     const day = wedding.getDate();
     const month = wedding.toLocaleString("en-GB", { month: "long" });
@@ -37,26 +37,49 @@ export default function ProfileHero({
     return {
       formattedDate: `${day}${ordinalSuffix(day)} ${month} ${year}`,
       countdownText: text,
+      variant: v,
+      daysAbs: abs,
+      rightEyebrow: eyebrow,
+      rightCaption: caption,
     };
   }, [weddingDate]);
 
   return (
-    <section className="text-center pt-12 pb-8 px-6">
-      <p className="wedsy-eyebrow">A WEDSY WEDDING</p>
-      <h1 className="wedsy-title text-[44px] leading-[1.05] mt-3 text-wedsy-ink">
-        {coupleName}
-      </h1>
-      <p className="wedsy-italic-em text-[18px] mt-2">{formattedDate}</p>
-      <div className="wedsy-ornament-divider my-6 mx-auto"></div>
-      <p className="text-[13px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium">
-        {countdownText}
-      </p>
-      {eventDayNames.length > 0 && (
-        <p className="wedsy-subtitle mt-4 text-[12px]">
-          {eventDayNames.join(" · ")} · {eventDayCount}{" "}
-          {eventDayCount === 1 ? "event" : "events"}
+    <section>
+      <div className="lg:hidden text-center pt-12 pb-8 px-6">
+        <p className="wedsy-eyebrow">A WEDSY WEDDING</p>
+        <h1 className="wedsy-title text-[44px] leading-[1.05] mt-3 text-wedsy-ink">
+          {coupleName}
+        </h1>
+        <p className="wedsy-italic-em text-[18px] mt-2">{formattedDate}</p>
+        <div className="wedsy-ornament-divider my-6 mx-auto"></div>
+        <p className="text-[13px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium">
+          {countdownText}
         </p>
-      )}
+        {eventDayNames.length > 0 && (
+          <p className="wedsy-subtitle mt-4 text-[12px]">
+            {eventDayNames.join(" · ")} · {eventDayCount}{" "}
+            {eventDayCount === 1 ? "event" : "events"}
+          </p>
+        )}
+      </div>
+      <div className="hidden lg:flex lg:items-stretch lg:gap-10 lg:pt-2 lg:pb-10 lg:border-b lg:border-wedsy-rose-100">
+        <div className="flex-1">
+          <p className="wedsy-eyebrow">A WEDSY WEDDING</p>
+          <h1 className="font-serif text-[56px] xl:text-[64px] font-normal leading-[1.04] tracking-[-0.6px] text-wedsy-ink mt-3">
+            {coupleName}
+          </h1>
+          <p className="font-serif italic text-[20px] text-wedsy-burgundy mt-3">{formattedDate}</p>
+        </div>
+        <div className="w-px self-stretch bg-wedsy-rose-100"></div>
+        <div className="w-[280px] text-right flex flex-col justify-center">
+          <p className="wedsy-eyebrow">{rightEyebrow}</p>
+          <p className="font-serif text-[88px] font-normal text-wedsy-burgundy leading-[0.9] tracking-[-2px] mt-2">
+            {variant === "today" ? "0" : daysAbs}
+          </p>
+          <p className="font-serif italic text-[17px] text-wedsy-rose-600 mt-2">{rightCaption}</p>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Third and final sub-sub-phase of 1.5.B. After this ships, the live /profile desktop dashboard substantially resembles the locked HTML mockup. Closes the full 1.5.B work group.

## What's in this PR

- `components/profile/ProfileHero.js` — adds a horizontal banner variant at lg+ breakpoint. Mobile layout preserved byte-identically (just wrapped in `lg:hidden`). Desktop variant works for all three states (future/today/past) per Decision A option a.
- `components/profile/DesktopLayout.js` — new BROWSE section in left rail with Wedding Store + Makeup & Beauty rows. NavRow consolidated to single `<Link href={href || '#'}>` for accessibility.

## What's NOT in this PR

- Timeline canvas (Phase 1.5.C — major creative-heavy build)
- Event week strip + stats row redesign (Phase 1.5.D)
- Right rail real content (Phase 1.5.E)
- Empty states desktop / past-event card desktop (Phase 1.5.F-G)

## Behavior summary

| Scenario | Behavior |
|---|---|
| Desktop /profile | Horizontal hero banner with variant-aware right side, BROWSE section in left rail |
| Mobile /profile | Hero unchanged (centered title); rails hidden, no BROWSE section |
| Long couple name | Wraps naturally (no whitespace-nowrap), hero gets slightly taller |
| future variant | Right side: COUNTDOWN / N / 'days to your wedding' |
| today variant | Right side: TODAY / 0 / 'your wedding day' |
| past variant | Right side: SINCE / N / 'days since your wedding' |
| Click Wedding Store | Routes to /wedding-store, legacy header reappears |
| Click Makeup & Beauty | Routes to /makeup-and-beauty, legacy header reappears |
| Keyboard Tab | All 13 left-rail nav rows focusable |

## Verification

- Build clean: /profile route bundle 11.1 kB / 223 kB (was 10.5 kB; +0.6 kB for desktop hero block + 2 lucide icons - 0.1 kB from NavRow consolidation)
- 3 visual checks passed (hero banner correct, BROWSE section + Makeup & Beauty route works, mobile unchanged)
- Tested against Rohaan's prod test event (844 days past) — past variant renders correctly

## Notion

Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a (Decision 11)