### PR TITLE
feat(profile): timeline canvas desktop component (Phase 1.5.C)

### DIFF
--- a/components/profile/TimelineCanvas.js
+++ b/components/profile/TimelineCanvas.js
@@ -1,0 +1,179 @@
+import { RefreshCw } from "lucide-react";
+
+function formatShortDate(date) {
+  if (!date) return "";
+  const day = date.getDate();
+  const month = date.toLocaleString("en-GB", { month: "short" });
+  return `${day} ${month}`;
+}
+
+function formatRelativeDate(isoDate) {
+  const due = new Date(isoDate);
+  const today = new Date();
+  const stripTime = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diff = Math.round((stripTime(due) - stripTime(today)) / 86400000);
+  if (diff < 0) {
+    const past = Math.abs(diff);
+    return `${past} day${past === 1 ? "" : "s"} overdue`;
+  }
+  if (diff === 0) return "today";
+  if (diff === 1) return "tomorrow";
+  if (diff <= 14) return `in ${diff} days`;
+  const day = due.getDate();
+  const month = due.toLocaleString("en-GB", { month: "short" });
+  return `${day} ${month}`;
+}
+
+function formatLabelDate(isoDate, status) {
+  const source = status === "COMPLETED" ? "done" : formatRelativeDate(isoDate);
+  return source;
+}
+
+function calculatePosition(dueDate, today, wedding) {
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+  const totalDays = (wedding - today) / 86400000;
+  if (totalDays <= 0) return 0;
+  const milestoneDays = (due - today) / 86400000;
+  const pct = (milestoneDays / totalDays) * 100;
+  return Math.max(0, Math.min(100, pct));
+}
+
+export default function TimelineCanvas({
+  milestones,
+  weddingDate,
+  loading,
+  error,
+  regenerating,
+  onRegenerate,
+}) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const wedding = weddingDate ? new Date(weddingDate) : null;
+  if (wedding) wedding.setHours(0, 0, 0, 0);
+  const isPastOrInvalid = !wedding || wedding < today;
+
+  if (isPastOrInvalid) return null;
+
+  const list = Array.isArray(milestones) ? milestones : [];
+  const visibleMilestones = list.filter((m) => !!m?.dueDate);
+  const milestonesWithoutDate = list.filter((m) => !m?.dueDate);
+
+  const upcoming = visibleMilestones
+    .filter((m) => m.status !== "COMPLETED")
+    .slice()
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate));
+  const nextMilestone = upcoming[0] || null;
+
+  return (
+    <section className="py-10 border-b border-wedsy-rose-100">
+      <div className="flex justify-between items-baseline mb-4">
+        <div>
+          <p className="wedsy-eyebrow">Planning timeline</p>
+          <h2 className="font-serif text-[30px] font-normal text-wedsy-ink mt-2">
+            Your road to the wedding
+          </h2>
+          <p className="font-serif italic text-[14px] text-wedsy-rose-600 mt-1">
+            Today on the left, the wedding on the right
+          </p>
+        </div>
+        <a className="text-[11px] tracking-[2px] uppercase text-wedsy-rose-600 font-medium cursor-pointer">
+          View all milestones →
+        </a>
+      </div>
+
+      <div className="relative h-[200px] mt-6 mb-4">
+        <div className="absolute left-0 right-0 top-[100px] h-px bg-wedsy-rose-100"></div>
+
+        <div className="absolute left-0 top-[80px]">
+          <p className="text-[10px] tracking-[2px] uppercase text-wedsy-rose-600 font-medium mb-1">Today</p>
+          <p className="font-serif italic text-[13px] text-wedsy-ink">{formatShortDate(today)}</p>
+        </div>
+        <div className="absolute w-[9px] h-[9px] rounded-full bg-wedsy-rose-600 top-[95.5px] left-[-4.5px]"></div>
+
+        <div className="absolute right-0 top-[80px] text-right">
+          <p className="text-[10px] tracking-[2px] uppercase text-wedsy-rose-600 font-medium mb-1">Wedding</p>
+          <p className="font-serif italic text-[13px] text-wedsy-ink">{formatShortDate(wedding)}</p>
+        </div>
+        <div className="absolute w-[9px] h-[9px] rounded-full bg-wedsy-burgundy top-[95.5px] right-[-4.5px]"></div>
+
+        {visibleMilestones.map((m, i) => {
+          const pos = calculatePosition(m.dueDate, today, wedding);
+          const isCompleted = m.status === "COMPLETED";
+          const isAI = m.source === "AI" && !isCompleted;
+          const labelAbove = i % 2 === 0;
+          const dotClasses = isCompleted
+            ? "bg-wedsy-ink-3 opacity-50"
+            : isAI
+            ? "bg-wedsy-rose-600"
+            : "bg-wedsy-ivory border-[1.5px] border-wedsy-rose-600";
+          return (
+            <div
+              key={m._id}
+              className="absolute group cursor-pointer"
+              style={{ left: `${pos}%`, top: "100px", transform: "translateX(-50%)" }}
+            >
+              <div
+                className={`relative w-[11px] h-[11px] rounded-full transition-transform hover:scale-150 ${dotClasses}`}
+                style={{ marginTop: "-5px" }}
+              >
+                {isAI && (
+                  <div className="absolute inset-[-4px] rounded-full border border-wedsy-rose-600 opacity-50 animate-ping"></div>
+                )}
+              </div>
+              <div
+                className={`absolute left-1/2 -translate-x-1/2 ${
+                  labelAbove ? "bottom-[18px]" : "top-[18px]"
+                } bg-wedsy-ivory border border-wedsy-rose-100 px-3 py-1.5 rounded-sm whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 shadow-sm`}
+              >
+                <p className={`text-[11px] text-wedsy-ink ${isCompleted ? "opacity-60" : ""}`}>{m.title}</p>
+                <p className="font-serif italic text-[10px] text-wedsy-rose-600 mt-0.5">
+                  {formatLabelDate(m.dueDate, m.status)}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {loading && (
+        <p className="text-center text-[12px] text-wedsy-ink-3 font-serif italic">Loading milestones…</p>
+      )}
+      {error && (
+        <p className="text-center text-[12px] text-wedsy-ink-3 font-serif italic">Unable to load timeline.</p>
+      )}
+
+      {nextMilestone ? (
+        <p className="font-serif italic text-[15px] text-wedsy-ink text-center pt-3">
+          Next: <span className="text-wedsy-burgundy">{nextMilestone.title}</span>, {formatRelativeDate(nextMilestone.dueDate)}
+          <button
+            onClick={onRegenerate}
+            disabled={regenerating}
+            className="ml-4 inline-flex items-center gap-1.5 text-[11px] tracking-[2px] uppercase text-wedsy-rose-600 font-medium align-middle hover:text-wedsy-burgundy disabled:opacity-50"
+          >
+            <RefreshCw size={12} className={regenerating ? "animate-spin" : ""} />
+            {regenerating ? "Regenerating…" : "Regenerate"}
+          </button>
+        </p>
+      ) : (
+        <p className="font-serif italic text-[15px] text-wedsy-ink text-center pt-3">
+          Tap Regenerate to start your timeline.
+          <button
+            onClick={onRegenerate}
+            disabled={regenerating}
+            className="ml-4 inline-flex items-center gap-1.5 text-[11px] tracking-[2px] uppercase text-wedsy-rose-600 font-medium align-middle hover:text-wedsy-burgundy disabled:opacity-50"
+          >
+            <RefreshCw size={12} className={regenerating ? "animate-spin" : ""} />
+            {regenerating ? "Regenerating…" : "Regenerate"}
+          </button>
+        </p>
+      )}
+
+      {milestonesWithoutDate.length > 0 && (
+        <p className="text-center text-[11px] text-wedsy-ink-3 mt-2">
+          {milestonesWithoutDate.length} milestone{milestonesWithoutDate.length === 1 ? "" : "s"} without a date — not shown on canvas
+        </p>
+      )}
+    </section>
+  );
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -6,6 +6,7 @@ import EventDaysCarousel from "@/components/profile/EventDaysCarousel";
 import InspirationCard from "@/components/profile/InspirationCard";
 import ProfileHero from "@/components/profile/ProfileHero";
 import StatsGrid from "@/components/profile/StatsGrid";
+import TimelineCanvas from "@/components/profile/TimelineCanvas";
 import TimelineCard from "@/components/profile/TimelineCard";
 import useProfileData from "@/hooks/useProfileData";
 import { regenerateTimeline } from "@/utils/api/wedding-timeline";
@@ -153,12 +154,12 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
               eventDayCount={event.eventDays?.length || 0}
               eventDayNames={deriveEventDayNames(event)}
             />
-            <TimelineCard
-              milestones={milestones}
-              onRegenerate={handleRegenerate}
-              onViewAll={() => console.log("Mock view all")}
-              regenerating={regenerating}
-            />
+            <div className="lg:hidden">
+              <TimelineCard milestones={milestones} onRegenerate={handleRegenerate} onViewAll={() => console.log("Mock view all")} regenerating={regenerating} />
+            </div>
+            <div className="hidden lg:block">
+              <TimelineCanvas milestones={milestones} weddingDate={deriveWeddingDate(event)} loading={milestonesLoading} error={milestonesError} regenerating={regenerating} onRegenerate={handleRegenerate} />
+            </div>
             {milestonesLoading && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Loading timeline…</p>}
             {milestonesError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Unable to load timeline. Please reload.</p>}
             {regenerateError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">{REGEN_ERROR_MESSAGES[regenerateError.code] || "Couldn't regenerate. Please try again."}</p>}


### PR DESCRIPTION
## Summary

Phase 1.5.C: horizontal date-axis timeline canvas at desktop breakpoints. Mobile keeps existing TimelineCard unchanged.

## What's in this PR

- New: `components/profile/TimelineCanvas.js` (179 lines)
- Modified: `pages/profile.js` — wraps TimelineCard in lg:hidden and TimelineCanvas in hidden lg:block

## What's NOT in this PR

- Suggestion-application UI (separate sub-phase — documented as gap in Phase 1.5 Design Lock)
- Event week strip + Stats row desktop (1.5.D)
- Right rail real content (1.5.E)
- Empty states desktop / past-event card desktop (1.5.F-G)

## Behavior summary

| Event state | Desktop /profile | Mobile /profile |
|---|---|---|
| Future event with milestones | Canvas with positioned dots, hover labels | Existing TimelineCard |
| Future event with zero milestones | Empty canvas + 'Tap Regenerate' caption | Existing TimelineCard 'No milestones yet' |
| Past event | Canvas returns null; past-event card from 1.4.C renders | Existing TimelineCard |

## Known limitation documented

Clicking Regenerate currently calls the AI endpoint successfully but doesn't apply suggestions to the database. The suggestion-application UI is a separate gap from Phase 1 and is documented in the Phase 1.5 Design Lock for future implementation. Not in 1.5.C scope.

## Verification

- Build clean: /profile route bundle 12.4 kB / 224 kB (was 11.1 kB; +1.3 kB for TimelineCanvas + RefreshCw icon)
- Past event (Rohaan's prod account, 844 days past): canvas returns null
- Future event (manually date-edited test): canvas renders with anchors and baseline, empty state caption visible
- Mobile (<1024px): TimelineCard renders unchanged

## Notion

Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a (suggestion-application gap section)