### PR TITLE
feat(profile): right rail real content + center workspace cleanup (Phase 1.5.E)

### DIFF
--- a/components/profile/DesktopLayout.js
+++ b/components/profile/DesktopLayout.js
@@ -1,4 +1,7 @@
 import EventSwitcherDropdown from "@/components/profile/EventSwitcherDropdown";
+import InspirationCard from "@/components/profile/InspirationCard";
+import NextUpCard from "@/components/profile/NextUpCard";
+import ThisWeekList from "@/components/profile/ThisWeekList";
 import {
   Bookmark,
   CalendarRange,
@@ -58,22 +61,18 @@ function SectionLabel({ children }) {
   );
 }
 
-function PlaceholderCard({ eyebrow, label }) {
-  return (
-    <div className="bg-white border border-wedsy-rose-100 rounded p-6">
-      <p className="text-[10px] tracking-[2px] uppercase font-medium text-wedsy-rose-600">{eyebrow}</p>
-      <p className="font-serif text-[16px] text-wedsy-ink mt-2">{label}</p>
-      <p className="font-serif italic text-[12px] text-wedsy-ink-3 mt-1">(coming in 1.5.E)</p>
-    </div>
-  );
-}
-
 export default function DesktopLayout({
   event,
   events,
+  milestones,
+  eventId,
+  token,
+  inspiration,
   onSwitchEvent,
   onCreateNewEvent,
   onManageAllEvents,
+  onMilestoneComplete,
+  onInspirationTap,
   children,
 }) {
   const monogram = deriveMonogram(event);
@@ -117,11 +116,22 @@ export default function DesktopLayout({
       <main className="lg:py-12 lg:px-14">{children}</main>
 
       <aside className="hidden lg:block bg-wedsy-ivory border-l border-wedsy-rose-100 px-7 py-14">
-        <div className="space-y-6">
-          <PlaceholderCard eyebrow="NEXT UP" label="Next-up callout" />
-          <PlaceholderCard eyebrow="INSPIRATION" label="Inspiration card" />
-          <PlaceholderCard eyebrow="THIS WEEK" label="This week" />
-        </div>
+        <NextUpCard
+          milestones={milestones}
+          eventId={eventId}
+          token={token}
+          onComplete={onMilestoneComplete}
+        />
+        {inspiration && (
+          <InspirationCard
+            imageSrc={inspiration.imageSrc}
+            tagline={inspiration.tagline}
+            headline={inspiration.headline}
+            ctaLabel={inspiration.ctaLabel}
+            onTap={onInspirationTap}
+          />
+        )}
+        <ThisWeekList milestones={milestones} />
       </aside>
     </div>
   );

--- a/components/profile/InspirationCard.js
+++ b/components/profile/InspirationCard.js
@@ -22,7 +22,7 @@ export default function InspirationCard({
         type="button"
         onClick={onTap}
         style={cardStyle}
-        className={`relative w-full aspect-[4/3] mt-5 border border-wedsy-rose-100 overflow-hidden text-left ${
+        className={`relative w-full aspect-[4/3] lg:aspect-[3/4] mt-5 border border-wedsy-rose-100 overflow-hidden text-left ${
           imageSrc ? "" : "bg-wedsy-rose-100"
         }`}
       >

--- a/components/profile/NextUpCard.js
+++ b/components/profile/NextUpCard.js
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { markMilestoneComplete } from "@/utils/api/wedding-timeline";
+
+function formatShortDate(isoDate) {
+  const d = new Date(isoDate);
+  const day = d.getDate();
+  const month = d.toLocaleString("en-GB", { month: "short" });
+  return `${day} ${month}`;
+}
+
+function formatRelativeDate(isoDate) {
+  const due = new Date(isoDate);
+  const today = new Date();
+  const stripTime = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diff = Math.round((stripTime(due) - stripTime(today)) / 86400000);
+  if (diff < 0) {
+    const past = Math.abs(diff);
+    return `${past} day${past === 1 ? "" : "s"} overdue`;
+  }
+  if (diff === 0) return "today";
+  if (diff === 1) return "tomorrow";
+  if (diff <= 14) return `in ${diff} days`;
+  return formatShortDate(isoDate);
+}
+
+export default function NextUpCard({ milestones, eventId, token, onComplete }) {
+  const [isMarking, setIsMarking] = useState(false);
+  const [error, setError] = useState(null);
+
+  const list = Array.isArray(milestones) ? milestones : [];
+  const nextMilestone = list
+    .filter((m) => m && m.status === "PENDING" && m.dueDate)
+    .slice()
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))[0];
+
+  if (!nextMilestone) return null;
+
+  const handleComplete = async () => {
+    if (!eventId || !token || isMarking) return;
+    setIsMarking(true);
+    setError(null);
+    const { error: err } = await markMilestoneComplete(eventId, nextMilestone._id, token);
+    if (err) {
+      setError("Couldn't mark complete. Try again.");
+      setIsMarking(false);
+      return;
+    }
+    setIsMarking(false);
+    if (onComplete) onComplete();
+  };
+
+  return (
+    <div className="bg-wedsy-ivory border border-wedsy-rose-100 p-6 mb-7">
+      <p className="wedsy-eyebrow mb-3">NEXT UP</p>
+      <p className="font-serif text-[22px] leading-[1.15] text-wedsy-ink">{nextMilestone.title}</p>
+      <p className="font-serif italic text-[14px] text-wedsy-burgundy mt-2">
+        {formatRelativeDate(nextMilestone.dueDate)} · {formatShortDate(nextMilestone.dueDate)}
+      </p>
+      <button
+        type="button"
+        onClick={handleComplete}
+        disabled={isMarking}
+        className="text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 hover:text-wedsy-burgundy disabled:opacity-50 mt-3"
+      >
+        {isMarking ? "Marking…" : "Mark as done →"}
+      </button>
+      {error && (
+        <p className="font-serif italic text-[11px] text-wedsy-ink-3 mt-2">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/profile/ThisWeekList.js
+++ b/components/profile/ThisWeekList.js
@@ -1,0 +1,40 @@
+export default function ThisWeekList({ milestones }) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const weekEnd = new Date(today);
+  weekEnd.setDate(weekEnd.getDate() + 7);
+  weekEnd.setHours(23, 59, 59, 999);
+
+  const list = Array.isArray(milestones) ? milestones : [];
+  const thisWeek = list
+    .filter((m) => {
+      if (!m || m.status !== "PENDING" || !m.dueDate) return false;
+      const due = new Date(m.dueDate);
+      return due >= today && due <= weekEnd;
+    })
+    .slice()
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate));
+
+  if (thisWeek.length === 0) return null;
+
+  return (
+    <div className="bg-wedsy-ivory border border-wedsy-rose-100 p-6 mb-7">
+      <p className="wedsy-eyebrow mb-4">THIS WEEK</p>
+      {thisWeek.map((m) => {
+        const due = new Date(m.dueDate);
+        const dayAbbr = due.toLocaleString("en-US", { weekday: "short" }).toUpperCase();
+        return (
+          <div
+            key={m._id}
+            className="flex items-start gap-3 py-2 border-b border-wedsy-rose-100 last:border-b-0"
+          >
+            <span className="text-[11px] tracking-[1.5px] uppercase text-wedsy-rose-600 font-medium w-[42px] shrink-0">
+              {dayAbbr}
+            </span>
+            <span className="text-[13px] text-wedsy-ink leading-[1.4]">{m.title}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -147,7 +147,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             onComplete={(data) => console.log("Mock complete event days:", data)}
           />
         ) : (
-          <DesktopLayout event={event} events={events} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll}>
+          <DesktopLayout event={event} events={events} milestones={milestones} eventId={event?._id} token={token} inspiration={MOCK_INSPIRATION} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll} onMilestoneComplete={refetchMilestones} onInspirationTap={() => console.log("Mock inspiration tap")}>
             <ProfileHero
               coupleName={deriveCoupleName(event)}
               weddingDate={deriveWeddingDate(event)}
@@ -172,17 +172,12 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             )}
             <EventDaysCarousel eventDays={event.eventDays || []} />
             <StatsGrid stats={MOCK_STATS} />
-            <InspirationCard
-              imageSrc={MOCK_INSPIRATION.imageSrc}
-              tagline={MOCK_INSPIRATION.tagline}
-              headline={MOCK_INSPIRATION.headline}
-              ctaLabel={MOCK_INSPIRATION.ctaLabel}
-              onTap={() => console.log("Mock inspiration tap")}
-            />
-            <AccountList
-              items={MOCK_ACCOUNT_ITEMS}
-              onSignOut={() => console.log("Mock sign out")}
-            />
+            <div className="lg:hidden">
+              <InspirationCard imageSrc={MOCK_INSPIRATION.imageSrc} tagline={MOCK_INSPIRATION.tagline} headline={MOCK_INSPIRATION.headline} ctaLabel={MOCK_INSPIRATION.ctaLabel} onTap={() => console.log("Mock inspiration tap")} />
+            </div>
+            <div className="lg:hidden">
+              <AccountList items={MOCK_ACCOUNT_ITEMS} onSignOut={() => console.log("Mock sign out")} />
+            </div>
           </DesktopLayout>
         )}
       </div>

--- a/utils/api/wedding-timeline.js
+++ b/utils/api/wedding-timeline.js
@@ -68,3 +68,12 @@ export async function regenerateTimeline(eventId, token) {
 export async function fetchEvents(token) {
   return authedRequest("GET", `/event`, token);
 }
+
+export async function markMilestoneComplete(eventId, milestoneId, token) {
+  return authedRequest(
+    "PATCH",
+    `/event/${eventId}/wedding-timeline/${milestoneId}`,
+    token,
+    { status: "COMPLETED" }
+  );
+}


### PR DESCRIPTION
## Summary

Phase 1.5.E: real right-rail components (NextUpCard, ThisWeekList, portrait Inspiration) + removes duplicate Inspiration/Account from center workspace at desktop.

## Files
- NEW: components/profile/NextUpCard.js (72 lines)
- NEW: components/profile/ThisWeekList.js (40 lines)
- MOD: components/profile/InspirationCard.js (+1 class — lg:aspect-[3/4])
- MOD: components/profile/DesktopLayout.js — new props, real right rail
- MOD: utils/api/wedding-timeline.js — adds markMilestoneComplete
- MOD: pages/profile.js — wraps mobile Inspiration/Account in lg:hidden

## Behavior
Desktop right rail shows NextUpCard / InspirationCard / ThisWeekList. Center workspace no longer shows duplicates at desktop. Mobile unchanged. NextUpCard's "Mark as done" CTA fires a real PATCH against the wedding-timeline endpoint.

## Known limitation
NextUpCard and ThisWeekList return null when zero milestones exist. Real users with milestones see populated cards. Test accounts with zero data see a sparse rail. Acceptable for ship.

## Notion
Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a