### PR TITLE
deploy: Phase 1.5 batched close-out — sub-phases E + F + G

### DIFF
--- a/components/profile/DesktopLayout.js
+++ b/components/profile/DesktopLayout.js
@@ -1,4 +1,7 @@
 import EventSwitcherDropdown from "@/components/profile/EventSwitcherDropdown";
+import InspirationCard from "@/components/profile/InspirationCard";
+import NextUpCard from "@/components/profile/NextUpCard";
+import ThisWeekList from "@/components/profile/ThisWeekList";
 import {
   Bookmark,
   CalendarRange,
@@ -58,22 +61,18 @@ function SectionLabel({ children }) {
   );
 }
 
-function PlaceholderCard({ eyebrow, label }) {
-  return (
-    <div className="bg-white border border-wedsy-rose-100 rounded p-6">
-      <p className="text-[10px] tracking-[2px] uppercase font-medium text-wedsy-rose-600">{eyebrow}</p>
-      <p className="font-serif text-[16px] text-wedsy-ink mt-2">{label}</p>
-      <p className="font-serif italic text-[12px] text-wedsy-ink-3 mt-1">(coming in 1.5.E)</p>
-    </div>
-  );
-}
-
 export default function DesktopLayout({
   event,
   events,
+  milestones,
+  eventId,
+  token,
+  inspiration,
   onSwitchEvent,
   onCreateNewEvent,
   onManageAllEvents,
+  onMilestoneComplete,
+  onInspirationTap,
   children,
 }) {
   const monogram = deriveMonogram(event);
@@ -117,11 +116,22 @@ export default function DesktopLayout({
       <main className="lg:py-12 lg:px-14">{children}</main>
 
       <aside className="hidden lg:block bg-wedsy-ivory border-l border-wedsy-rose-100 px-7 py-14">
-        <div className="space-y-6">
-          <PlaceholderCard eyebrow="NEXT UP" label="Next-up callout" />
-          <PlaceholderCard eyebrow="INSPIRATION" label="Inspiration card" />
-          <PlaceholderCard eyebrow="THIS WEEK" label="This week" />
-        </div>
+        <NextUpCard
+          milestones={milestones}
+          eventId={eventId}
+          token={token}
+          onComplete={onMilestoneComplete}
+        />
+        {inspiration && (
+          <InspirationCard
+            imageSrc={inspiration.imageSrc}
+            tagline={inspiration.tagline}
+            headline={inspiration.headline}
+            ctaLabel={inspiration.ctaLabel}
+            onTap={onInspirationTap}
+          />
+        )}
+        <ThisWeekList milestones={milestones} />
       </aside>
     </div>
   );

--- a/components/profile/EmptyStateStep1.js
+++ b/components/profile/EmptyStateStep1.js
@@ -14,12 +14,12 @@ export default function EmptyStateStep1({ onContinue }) {
   };
 
   return (
-    <section className="text-center pt-12 pb-10 px-6">
+    <section className="text-center pt-12 pb-10 px-6 lg:max-w-[600px] lg:mx-auto lg:py-16">
       <p className="wedsy-eyebrow">STEP 1 OF 2</p>
-      <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink">
+      <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink lg:text-[44px]">
         Tell us about your wedding
       </h1>
-      <p className="wedsy-italic-em text-[15px] mt-2">
+      <p className="wedsy-italic-em text-[15px] mt-2 lg:text-[16px]">
         We&apos;ll build your dashboard around this
       </p>
       <div className="wedsy-ornament-divider my-6 mx-auto"></div>
@@ -71,7 +71,7 @@ export default function EmptyStateStep1({ onContinue }) {
         type="button"
         disabled={!canContinue}
         onClick={handleContinue}
-        className="mt-10 w-full py-3 bg-wedsy-rose-600 text-white text-[13px] tracking-[2px] uppercase font-medium disabled:bg-wedsy-ink-3 disabled:cursor-not-allowed transition-colors"
+        className="mt-10 w-full py-3 bg-wedsy-rose-600 text-white text-[13px] tracking-[2px] uppercase font-medium disabled:bg-wedsy-ink-3 disabled:cursor-not-allowed transition-colors lg:w-auto lg:px-12 lg:mx-auto lg:block"
       >
         Continue
       </button>

--- a/components/profile/EmptyStateStep2.js
+++ b/components/profile/EmptyStateStep2.js
@@ -31,11 +31,11 @@ export default function EmptyStateStep2({ eventName, community, onBack, onComple
   };
 
   return (
-    <section className="pt-12 pb-10 px-6">
+    <section className="pt-12 pb-10 px-6 lg:max-w-[720px] lg:mx-auto lg:py-16">
       <div className="text-center">
         <p className="wedsy-eyebrow">STEP 2 OF 2</p>
-        <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink">Your celebration days</h1>
-        <p className="wedsy-italic-em text-[15px] mt-2">Add each event of your wedding</p>
+        <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink lg:text-[44px]">Your celebration days</h1>
+        <p className="wedsy-italic-em text-[15px] mt-2 lg:text-[16px]">Add each event of your wedding</p>
         <div className="wedsy-ornament-divider my-6 mx-auto"></div>
         <p className="text-[12px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium">{eventName} · {community}</p>
       </div>
@@ -67,7 +67,7 @@ export default function EmptyStateStep2({ eventName, community, onBack, onComple
         </div>
       )}
 
-      <div className="mt-6 space-y-4">
+      <div className="mt-6 space-y-4 lg:grid lg:grid-cols-2 lg:gap-4 lg:space-y-0">
         {eventDays.map((day, idx) => (
           <div key={idx} className="relative bg-wedsy-ivory-2 border border-wedsy-rose-100 p-4">
             <button
@@ -106,7 +106,7 @@ export default function EmptyStateStep2({ eventName, community, onBack, onComple
       <button
         type="button"
         onClick={addDay}
-        className="mt-4 w-full py-2 border border-wedsy-rose-400 text-wedsy-rose-600 text-[12px] tracking-[1px] uppercase font-medium hover:bg-wedsy-rose-50 transition-colors"
+        className="mt-4 w-full py-2 border border-wedsy-rose-400 text-wedsy-rose-600 text-[12px] tracking-[1px] uppercase font-medium hover:bg-wedsy-rose-50 transition-colors lg:w-auto lg:px-8 lg:mx-auto lg:block"
       >
         + Add another day
       </button>

--- a/components/profile/InspirationCard.js
+++ b/components/profile/InspirationCard.js
@@ -22,7 +22,7 @@ export default function InspirationCard({
         type="button"
         onClick={onTap}
         style={cardStyle}
-        className={`relative w-full aspect-[4/3] mt-5 border border-wedsy-rose-100 overflow-hidden text-left ${
+        className={`relative w-full aspect-[4/3] lg:aspect-[3/4] mt-5 border border-wedsy-rose-100 overflow-hidden text-left ${
           imageSrc ? "" : "bg-wedsy-rose-100"
         }`}
       >

--- a/components/profile/NextUpCard.js
+++ b/components/profile/NextUpCard.js
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { markMilestoneComplete } from "@/utils/api/wedding-timeline";
+
+function formatShortDate(isoDate) {
+  const d = new Date(isoDate);
+  const day = d.getDate();
+  const month = d.toLocaleString("en-GB", { month: "short" });
+  return `${day} ${month}`;
+}
+
+function formatRelativeDate(isoDate) {
+  const due = new Date(isoDate);
+  const today = new Date();
+  const stripTime = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diff = Math.round((stripTime(due) - stripTime(today)) / 86400000);
+  if (diff < 0) {
+    const past = Math.abs(diff);
+    return `${past} day${past === 1 ? "" : "s"} overdue`;
+  }
+  if (diff === 0) return "today";
+  if (diff === 1) return "tomorrow";
+  if (diff <= 14) return `in ${diff} days`;
+  return formatShortDate(isoDate);
+}
+
+export default function NextUpCard({ milestones, eventId, token, onComplete }) {
+  const [isMarking, setIsMarking] = useState(false);
+  const [error, setError] = useState(null);
+
+  const list = Array.isArray(milestones) ? milestones : [];
+  const nextMilestone = list
+    .filter((m) => m && m.status === "PENDING" && m.dueDate)
+    .slice()
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))[0];
+
+  if (!nextMilestone) return null;
+
+  const handleComplete = async () => {
+    if (!eventId || !token || isMarking) return;
+    setIsMarking(true);
+    setError(null);
+    const { error: err } = await markMilestoneComplete(eventId, nextMilestone._id, token);
+    if (err) {
+      setError("Couldn't mark complete. Try again.");
+      setIsMarking(false);
+      return;
+    }
+    setIsMarking(false);
+    if (onComplete) onComplete();
+  };
+
+  return (
+    <div className="bg-wedsy-ivory border border-wedsy-rose-100 p-6 mb-7">
+      <p className="wedsy-eyebrow mb-3">NEXT UP</p>
+      <p className="font-serif text-[22px] leading-[1.15] text-wedsy-ink">{nextMilestone.title}</p>
+      <p className="font-serif italic text-[14px] text-wedsy-burgundy mt-2">
+        {formatRelativeDate(nextMilestone.dueDate)} · {formatShortDate(nextMilestone.dueDate)}
+      </p>
+      <button
+        type="button"
+        onClick={handleComplete}
+        disabled={isMarking}
+        className="text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 hover:text-wedsy-burgundy disabled:opacity-50 mt-3"
+      >
+        {isMarking ? "Marking…" : "Mark as done →"}
+      </button>
+      {error && (
+        <p className="font-serif italic text-[11px] text-wedsy-ink-3 mt-2">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/profile/ThisWeekList.js
+++ b/components/profile/ThisWeekList.js
@@ -1,0 +1,40 @@
+export default function ThisWeekList({ milestones }) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const weekEnd = new Date(today);
+  weekEnd.setDate(weekEnd.getDate() + 7);
+  weekEnd.setHours(23, 59, 59, 999);
+
+  const list = Array.isArray(milestones) ? milestones : [];
+  const thisWeek = list
+    .filter((m) => {
+      if (!m || m.status !== "PENDING" || !m.dueDate) return false;
+      const due = new Date(m.dueDate);
+      return due >= today && due <= weekEnd;
+    })
+    .slice()
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate));
+
+  if (thisWeek.length === 0) return null;
+
+  return (
+    <div className="bg-wedsy-ivory border border-wedsy-rose-100 p-6 mb-7">
+      <p className="wedsy-eyebrow mb-4">THIS WEEK</p>
+      {thisWeek.map((m) => {
+        const due = new Date(m.dueDate);
+        const dayAbbr = due.toLocaleString("en-US", { weekday: "short" }).toUpperCase();
+        return (
+          <div
+            key={m._id}
+            className="flex items-start gap-3 py-2 border-b border-wedsy-rose-100 last:border-b-0"
+          >
+            <span className="text-[11px] tracking-[1.5px] uppercase text-wedsy-rose-600 font-medium w-[42px] shrink-0">
+              {dayAbbr}
+            </span>
+            <span className="text-[13px] text-wedsy-ink leading-[1.4]">{m.title}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -147,7 +147,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             onComplete={(data) => console.log("Mock complete event days:", data)}
           />
         ) : (
-          <DesktopLayout event={event} events={events} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll}>
+          <DesktopLayout event={event} events={events} milestones={milestones} eventId={event?._id} token={token} inspiration={MOCK_INSPIRATION} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll} onMilestoneComplete={refetchMilestones} onInspirationTap={() => console.log("Mock inspiration tap")}>
             <ProfileHero
               coupleName={deriveCoupleName(event)}
               weddingDate={deriveWeddingDate(event)}
@@ -172,17 +172,12 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             )}
             <EventDaysCarousel eventDays={event.eventDays || []} />
             <StatsGrid stats={MOCK_STATS} />
-            <InspirationCard
-              imageSrc={MOCK_INSPIRATION.imageSrc}
-              tagline={MOCK_INSPIRATION.tagline}
-              headline={MOCK_INSPIRATION.headline}
-              ctaLabel={MOCK_INSPIRATION.ctaLabel}
-              onTap={() => console.log("Mock inspiration tap")}
-            />
-            <AccountList
-              items={MOCK_ACCOUNT_ITEMS}
-              onSignOut={() => console.log("Mock sign out")}
-            />
+            <div className="lg:hidden">
+              <InspirationCard imageSrc={MOCK_INSPIRATION.imageSrc} tagline={MOCK_INSPIRATION.tagline} headline={MOCK_INSPIRATION.headline} ctaLabel={MOCK_INSPIRATION.ctaLabel} onTap={() => console.log("Mock inspiration tap")} />
+            </div>
+            <div className="lg:hidden">
+              <AccountList items={MOCK_ACCOUNT_ITEMS} onSignOut={() => console.log("Mock sign out")} />
+            </div>
           </DesktopLayout>
         )}
       </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -164,10 +164,10 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
             {milestonesError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">Unable to load timeline. Please reload.</p>}
             {regenerateError && <p className="px-6 -mt-4 mb-6 font-serif italic text-[12px] text-wedsy-ink-3 text-center">{REGEN_ERROR_MESSAGES[regenerateError.code] || "Couldn't regenerate. Please try again."}</p>}
             {showPastEventCard && (
-              <div className="px-6 mt-4 mb-8 text-center">
-                <p className="font-serif italic text-[15px] text-wedsy-ink leading-snug">Your celebration is complete — we hope it was unforgettable.</p>
-                <p className="font-sans text-[12px] text-wedsy-ink-3 mt-3 mb-3">Planning another?</p>
-                <button onClick={handleCreateNewEvent} className="text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600">Create a new event →</button>
+              <div className="px-6 mt-4 mb-8 text-center lg:max-w-[720px] lg:mx-auto lg:py-16">
+                <p className="font-serif italic text-[15px] text-wedsy-ink leading-snug lg:text-[20px] lg:leading-[1.4]">Your celebration is complete — we hope it was unforgettable.</p>
+                <p className="font-sans text-[12px] text-wedsy-ink-3 mt-3 mb-3 lg:text-[14px] lg:mt-6 lg:mb-5">Planning another?</p>
+                <button onClick={handleCreateNewEvent} className="text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 lg:text-[12px] lg:tracking-[3px] hover:text-wedsy-burgundy">Create a new event →</button>
               </div>
             )}
             <EventDaysCarousel eventDays={event.eventDays || []} />

--- a/utils/api/wedding-timeline.js
+++ b/utils/api/wedding-timeline.js
@@ -68,3 +68,12 @@ export async function regenerateTimeline(eventId, token) {
 export async function fetchEvents(token) {
   return authedRequest("GET", `/event`, token);
 }
+
+export async function markMilestoneComplete(eventId, milestoneId, token) {
+  return authedRequest(
+    "PATCH",
+    `/event/${eventId}/wedding-timeline/${milestoneId}`,
+    token,
+    { status: "COMPLETED" }
+  );
+}


### PR DESCRIPTION
## Summary

Final batched deploy closing Phase 1.5. Ships three sub-phases in a single CloudFront invalidation per the deploy policy locked 12 May 2026.

## Sub-phases shipped

- **1.5.E** (c86fc8c) — Right rail real content + center workspace cleanup. New NextUpCard + ThisWeekList components, portrait Inspiration at desktop, mobile duplicates hidden via lg:hidden, markMilestoneComplete helper.
- **1.5.F** (57815bf) — Empty State Step 1 + Step 2 desktop variants. Tailwind responsive prefixes only.
- **1.5.G** (aea27e0) — Past-event card desktop variant. Tailwind responsive prefixes only on inline block in profile.js.

## What's NOT in this PR

- No code changes from 1.5.H itself (verification + Notion docs only)
- Suggestion-application UI gap remains (documented in Phase 1.5 Design Lock as future sub-phase)
- Bride/Groom name field separation (planned as Sub-phase 1.5.5, separate)

## Phase 1.5 completion status

This is the eighth and final sub-phase of Phase 1.5. After this ships, Phase 1.5 (Desktop UI Redesign) is fully complete and live in production at wedsy.in/profile.

## Notion

- Phase 1.5 Design Lock: https://www.notion.so/35d72ef954ed81d683bbfe8b853f3b7a
- Project Master Index: https://www.notion.so/35a72ef954ed817ab83ad413b0866bd1