### PR TITLE
Sub-phase 1.5.6.2: Inline event-day editor with Add/Delete + planner CTA

### DIFF
--- a/components/profile/EventDaysCarousel.js
+++ b/components/profile/EventDaysCarousel.js
@@ -9,7 +9,7 @@ function formatDay(isoDate) {
 const SPELLED = ["Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"];
 const spell = (n) => (n < SPELLED.length ? SPELLED[n] : String(n));
 
-export default function EventDaysCarousel({ eventDays = [] }) {
+export default function EventDaysCarousel({ eventDays = [], onCardClick }) {
   const heading =
     eventDays.length === 1
       ? "One day of celebration"
@@ -31,7 +31,10 @@ export default function EventDaysCarousel({ eventDays = [] }) {
           eventDays.map((day, i) => (
             <article
               key={i}
-              className="w-[260px] shrink-0 bg-wedsy-ivory-2 border border-wedsy-rose-100 p-5 lg:w-auto"
+              onClick={onCardClick ? () => onCardClick(i) : undefined}
+              className={`w-[260px] shrink-0 bg-wedsy-ivory-2 border border-wedsy-rose-100 p-5 lg:w-auto ${
+                onCardClick ? "cursor-pointer lg:hover:border-wedsy-rose-600 lg:transition-colors" : ""
+              }`}
             >
               <p className="text-[10px] tracking-[1px] uppercase font-medium text-wedsy-rose-600">
                 Day {i + 1}

--- a/components/profile/EventDaysEditor.js
+++ b/components/profile/EventDaysEditor.js
@@ -1,0 +1,260 @@
+import { useEffect, useRef, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { updateEvent } from "@/utils/api/wedding-timeline";
+
+const inputClass =
+  "w-full bg-wedsy-ivory-2 border border-wedsy-rose-100 px-3 py-2 text-[14px] text-wedsy-ink focus:outline-none focus:border-wedsy-burgundy-soft transition-colors";
+
+function FieldGroup({ label, error, children }) {
+  return (
+    <div>
+      <label className="block text-[10px] tracking-[1.5px] uppercase text-wedsy-ink-3 font-medium mb-1">
+        {label}
+      </label>
+      {children}
+      {error && <p className="text-[11px] text-wedsy-burgundy mt-1">{error}</p>}
+    </div>
+  );
+}
+
+function toDateInputValue(value) {
+  if (!value) return "";
+  if (/^\d{4}-\d{2}-\d{2}/.test(value)) return value.slice(0, 10);
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return "";
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function toTimeInputValue(value) {
+  if (!value) return "";
+  if (/^\d{2}:\d{2}$/.test(value)) return value;
+  const match = String(value).match(/(\d{1,2}):(\d{2})/);
+  if (!match) return "";
+  return `${match[1].padStart(2, "0")}:${match[2]}`;
+}
+
+function normalizeDayForEditing(day) {
+  return {
+    ...day,
+    date: toDateInputValue(day?.date),
+    time: toTimeInputValue(day?.time),
+    name: day?.name || "",
+    venue: day?.venue || "",
+  };
+}
+
+export default function EventDaysEditor({
+  eventDays,
+  eventId,
+  token,
+  focusIndex,
+  onSave,
+  onCancel,
+}) {
+  const [editingDays, setEditingDays] = useState(() =>
+    (eventDays || []).map(normalizeDayForEditing)
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+  const [validationErrors, setValidationErrors] = useState({});
+  const [confirmingDeleteIndex, setConfirmingDeleteIndex] = useState(null);
+  const [pendingFocusIndex, setPendingFocusIndex] = useState(null);
+  const refsArray = useRef([]);
+
+  useEffect(() => {
+    if (focusIndex == null) return;
+    const row = refsArray.current[focusIndex];
+    if (!row) return;
+    const input = row.querySelector("input");
+    if (input) input.focus();
+  }, [focusIndex]);
+
+  useEffect(() => {
+    if (pendingFocusIndex == null) return;
+    const row = refsArray.current[pendingFocusIndex];
+    if (!row) return;
+    const input = row.querySelector("input");
+    if (input) input.focus();
+    setPendingFocusIndex(null);
+  }, [pendingFocusIndex]);
+
+  const handleAddDay = () => {
+    setEditingDays((days) => {
+      const next = [...days, { name: "", date: "", time: "", venue: "" }];
+      setPendingFocusIndex(next.length - 1);
+      return next;
+    });
+  };
+
+  const handleRemoveDay = (index) => {
+    setEditingDays((days) => days.filter((_, i) => i !== index));
+    setConfirmingDeleteIndex(null);
+    setValidationErrors((errors) => {
+      const next = {};
+      Object.entries(errors).forEach(([key, val]) => {
+        const idx = parseInt(key, 10);
+        if (idx < index) next[idx] = val;
+        else if (idx > index) next[idx - 1] = val;
+      });
+      return next;
+    });
+  };
+
+  const updateField = (i, field, value) => {
+    setEditingDays((days) =>
+      days.map((d, idx) => (idx === i ? { ...d, [field]: value } : d))
+    );
+    setValidationErrors((prev) => {
+      if (!prev[i] || !prev[i][field]) return prev;
+      const next = { ...prev, [i]: { ...prev[i] } };
+      delete next[i][field];
+      if (Object.keys(next[i]).length === 0) delete next[i];
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    const errors = {};
+    editingDays.forEach((day, i) => {
+      const rowErrors = {};
+      if (!day.name?.trim()) rowErrors.name = "Required";
+      if (!day.date) rowErrors.date = "Required";
+      if (!day.time) rowErrors.time = "Required";
+      if (!day.venue?.trim()) rowErrors.venue = "Required";
+      if (Object.keys(rowErrors).length > 0) errors[i] = rowErrors;
+    });
+    setValidationErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setIsSaving(true);
+    setSaveError(null);
+    const payload = {
+      eventDays: editingDays.map((d) => ({
+        ...d,
+        name: d.name.trim(),
+        venue: d.venue.trim(),
+      })),
+    };
+    const { error } = await updateEvent(eventId, payload, token);
+    if (error) {
+      setSaveError("Couldn't save changes. Try again.");
+      setIsSaving(false);
+      return;
+    }
+    setIsSaving(false);
+    if (onSave) await onSave();
+  };
+
+  return (
+    <div className="bg-wedsy-ivory border border-wedsy-rose-100 mt-4 mx-6 lg:mx-0 p-5 lg:p-6">
+      <div className="flex justify-between items-baseline mb-4">
+        <p className="wedsy-eyebrow">EDIT EVENT DAYS</p>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="text-[11px] tracking-[2px] uppercase text-wedsy-ink-3 hover:text-wedsy-burgundy font-medium disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {editingDays.map((day, i) => (
+          <div
+            key={i}
+            ref={(el) => {
+              refsArray.current[i] = el;
+            }}
+            className="border border-wedsy-rose-100 bg-white p-4 space-y-3 lg:grid lg:grid-cols-[1fr_1fr_120px_1.5fr_auto] lg:gap-3 lg:space-y-0 lg:items-end"
+          >
+            <FieldGroup label="Day name" error={validationErrors[i]?.name}>
+              <input
+                type="text"
+                value={day.name}
+                onChange={(e) => updateField(i, "name", e.target.value)}
+                className={inputClass}
+                placeholder="e.g., Mehendi"
+              />
+            </FieldGroup>
+            <FieldGroup label="Date" error={validationErrors[i]?.date}>
+              <input
+                type="date"
+                value={day.date}
+                onChange={(e) => updateField(i, "date", e.target.value)}
+                className={inputClass}
+              />
+            </FieldGroup>
+            <FieldGroup label="Time" error={validationErrors[i]?.time}>
+              <input
+                type="time"
+                value={day.time}
+                onChange={(e) => updateField(i, "time", e.target.value)}
+                className={inputClass}
+              />
+            </FieldGroup>
+            <FieldGroup label="Venue" error={validationErrors[i]?.venue}>
+              <input
+                type="text"
+                value={day.venue}
+                onChange={(e) => updateField(i, "venue", e.target.value)}
+                className={inputClass}
+                placeholder="e.g., Bangalore International Centre"
+              />
+            </FieldGroup>
+            {editingDays.length > 1 ? (
+              confirmingDeleteIndex === i ? (
+                <div className="flex items-center gap-2 lg:justify-self-end pt-2 lg:pt-0">
+                  <span className="font-serif italic text-[12px] text-wedsy-burgundy">Remove?</span>
+                  <button type="button" onClick={() => handleRemoveDay(i)} className="text-[11px] tracking-[1.5px] uppercase text-wedsy-burgundy hover:text-wedsy-rose-600 font-medium">Yes</button>
+                  <button type="button" onClick={() => setConfirmingDeleteIndex(null)} className="text-[11px] tracking-[1.5px] uppercase text-wedsy-ink-3 hover:text-wedsy-ink">Cancel</button>
+                </div>
+              ) : (
+                <button type="button" onClick={() => setConfirmingDeleteIndex(i)} aria-label="Remove this day" className="text-wedsy-ink-3 hover:text-wedsy-burgundy lg:justify-self-end p-1">
+                  <Trash2 size={16} />
+                </button>
+              )
+            ) : (
+              <div title="Need at least one day" className="text-wedsy-ink-3 opacity-30 lg:justify-self-end p-1">
+                <Trash2 size={16} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <button type="button" onClick={handleAddDay} disabled={isSaving} className="mt-4 inline-flex items-center gap-2 text-[11px] tracking-[2px] uppercase text-wedsy-rose-600 hover:text-wedsy-burgundy font-medium disabled:opacity-50">
+        <Plus size={14} />
+        Add another day
+      </button>
+
+      {saveError && (
+        <p className="font-serif italic text-[12px] text-wedsy-burgundy mt-3 text-center">
+          {saveError}
+        </p>
+      )}
+
+      <div className="mt-6 flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="text-[11px] tracking-[2px] uppercase text-wedsy-ink-3 px-6 py-3 hover:text-wedsy-burgundy font-medium disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving}
+          className="text-[11px] tracking-[2px] uppercase bg-wedsy-burgundy text-wedsy-ivory px-8 py-3 hover:bg-wedsy-burgundy-soft font-medium disabled:opacity-50"
+        >
+          {isSaving ? "Saving…" : "Save changes"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/hooks/useProfileData.js
+++ b/hooks/useProfileData.js
@@ -48,12 +48,9 @@ export default function useProfileData({ token, selectedEventId }) {
     [token]
   );
 
-  useEffect(() => {
-    const loadAll = async () => {
-      if (!token) {
-        // Idle until a real token arrives. Initial eventLoading=true holds.
-        return;
-      }
+  const loadEvent = useCallback(
+    async ({ loadMilestonesAfter = true } = {}) => {
+      if (!token) return;
       if (isMountedRef.current) {
         setEventLoading(true);
         setEventError(null);
@@ -75,19 +72,27 @@ export default function useProfileData({ token, selectedEventId }) {
       if (!chosen) chosen = pickPrimaryEvent(eventList);
       setEvent(chosen);
       setEventLoading(false);
-      if (chosen?._id) {
+      if (loadMilestonesAfter && chosen?._id) {
         loadMilestones(chosen._id);
-      } else {
+      } else if (loadMilestonesAfter) {
         setMilestones([]);
       }
-    };
-    loadAll();
-  }, [token, loadMilestones, selectedEventId]);
+    },
+    [token, selectedEventId, loadMilestones]
+  );
+
+  useEffect(() => {
+    loadEvent();
+  }, [loadEvent]);
 
   const refetchMilestones = useCallback(() => {
     if (event?._id) return loadMilestones(event._id);
     return Promise.resolve();
   }, [event, loadMilestones]);
+
+  const refetchEvent = useCallback(() => {
+    return loadEvent({ loadMilestonesAfter: false });
+  }, [loadEvent]);
 
   return {
     event,
@@ -98,5 +103,6 @@ export default function useProfileData({ token, selectedEventId }) {
     milestonesLoading,
     milestonesError,
     refetchMilestones,
+    refetchEvent,
   };
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -3,6 +3,7 @@ import DesktopLayout from "@/components/profile/DesktopLayout";
 import EmptyStateStep1 from "@/components/profile/EmptyStateStep1";
 import EmptyStateStep2 from "@/components/profile/EmptyStateStep2";
 import EventDaysCarousel from "@/components/profile/EventDaysCarousel";
+import EventDaysEditor from "@/components/profile/EventDaysEditor";
 import InspirationCard from "@/components/profile/InspirationCard";
 import ProfileHero from "@/components/profile/ProfileHero";
 import StatsGrid from "@/components/profile/StatsGrid";
@@ -11,6 +12,7 @@ import TimelineCard from "@/components/profile/TimelineCard";
 import useProfileData from "@/hooks/useProfileData";
 import { regenerateTimeline } from "@/utils/api/wedding-timeline";
 import Head from "next/head";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
@@ -70,6 +72,8 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
   const [regenerateError, setRegenerateError] = useState(null);
   const [regenerateResult, setRegenerateResult] = useState(null);
   const [selectedEventId, setSelectedEventId] = useState(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editorFocusIndex, setEditorFocusIndex] = useState(null);
 
   useEffect(() => {
     CheckLogin();
@@ -100,6 +104,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     milestonesLoading,
     milestonesError,
     refetchMilestones,
+    refetchEvent,
   } = useProfileData({ token, selectedEventId });
 
   if (!user?.name) {
@@ -153,12 +158,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
           />
         ) : (
           <DesktopLayout event={event} events={events} milestones={milestones} eventId={event?._id} token={token} inspiration={MOCK_INSPIRATION} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll} onMilestoneComplete={refetchMilestones} onInspirationTap={() => console.log("Mock inspiration tap")}>
-            <ProfileHero
-              coupleName={deriveCoupleName(event)}
-              weddingDate={deriveWeddingDate(event)}
-              eventDayCount={event.eventDays?.length || 0}
-              eventDayNames={deriveEventDayNames(event)}
-            />
+            <ProfileHero coupleName={deriveCoupleName(event)} weddingDate={deriveWeddingDate(event)} eventDayCount={event.eventDays?.length || 0} eventDayNames={deriveEventDayNames(event)} />
             <div className="lg:hidden">
               <TimelineCard milestones={milestones} onRegenerate={handleRegenerate} onViewAll={() => console.log("Mock view all")} regenerating={regenerating} />
             </div>
@@ -175,7 +175,15 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
                 <button onClick={handleCreateNewEvent} className="text-[11px] tracking-[2px] uppercase font-medium text-wedsy-rose-600 lg:text-[12px] lg:tracking-[3px] hover:text-wedsy-burgundy">Create a new event →</button>
               </div>
             )}
-            <EventDaysCarousel eventDays={event.eventDays || []} />
+            <EventDaysCarousel eventDays={event.eventDays || []} onCardClick={(i) => { setEditorFocusIndex(i); setEditorOpen(true); }} />
+            {editorOpen && event._id && (
+              <EventDaysEditor eventDays={event.eventDays || []} eventId={event._id} token={token} focusIndex={editorFocusIndex} onSave={async () => { await refetchEvent(); setEditorOpen(false); setEditorFocusIndex(null); }} onCancel={() => { setEditorOpen(false); setEditorFocusIndex(null); }} />
+            )}
+            {!editorOpen && event._id && (
+              <div className="mt-4 text-center">
+                <Link href={`/event/${event._id}/planner`} className="inline-block text-[11px] tracking-[2px] uppercase text-wedsy-rose-600 hover:text-wedsy-burgundy font-medium">View event planner →</Link>
+              </div>
+            )}
             <StatsGrid stats={MOCK_STATS} />
             <div className="lg:hidden">
               <InspirationCard imageSrc={MOCK_INSPIRATION.imageSrc} tagline={MOCK_INSPIRATION.tagline} headline={MOCK_INSPIRATION.headline} ctaLabel={MOCK_INSPIRATION.ctaLabel} onTap={() => console.log("Mock inspiration tap")} />

--- a/utils/api/wedding-timeline.js
+++ b/utils/api/wedding-timeline.js
@@ -77,3 +77,7 @@ export async function markMilestoneComplete(eventId, milestoneId, token) {
     { status: "COMPLETED" }
   );
 }
+
+export async function updateEvent(eventId, payload, token) {
+  return authedRequest("PUT", `/event/${eventId}`, token, payload);
+}


### PR DESCRIPTION
## Summary

Adds an inline editor below the event-days carousel on `/profile`. Clicking an event-day card opens a slide-down panel pre-focused on that row. Users can edit name/date/time/venue per day, add new days, or delete days (with inline "Remove? Yes/Cancel" confirmation). Delete is disabled when only one day remains. Save commits the full eventDays array atomically via `PUT /event/:id` (unblocked by backend sub-phase 1.5.6.1 — wedsy-server `962dc38`, already live in production).

A "View event planner →" CTA renders below the carousel when the editor is closed, routing to `/event/{eventId}/planner`.

## Files changed

| File | Change |
|---|---|
| `components/profile/EventDaysEditor.js` | NEW (260 lines) |
| `components/profile/EventDaysCarousel.js` | `+onCardClick` prop |
| `hooks/useProfileData.js` | `+refetchEvent`, `loadEvent` refactor |
| `pages/profile.js` | Editor open state, planner CTA, wire-up |
| `utils/api/wedding-timeline.js` | `+updateEvent` helper |

Total: 5 files, +301 / -20.

## Behavior

- **Validation gates Save** — every day requires name + date + time + venue (matches backend contract). Empty fields show inline "Required" errors that clear on keystroke.
- **Cancel** from either button (top-right or bottom-left) closes without firing a PUT.
- **Add** appends a blank row and auto-focuses the new row's Day name input.
- **Delete** requires inline confirmation; disabled when only one day remains; only one row at a time can be in "confirming delete" state.
- **Responsive** — horizontal 5-column grid at lg+ (≥1024px), stacks vertically below.
- **Save** is atomic — all Add/Delete/Modify mutations within a single editor session commit in one PUT.
- After save, parent re-fetches the event (without re-fetching milestones) via a new `refetchEvent` on `useProfileData`.

## Verification

Verified manually against production backend across 10 tests on Chrome 1440×900 and 390px:

| # | Test | Result |
|---|---|---|
| 1 | Desktop click-to-edit at ≥1024px | ✅ |
| 2 | Mobile click-to-edit at <1024px | ✅ |
| 3 | Real PUT against production (reversible Time edit on Haldi day) | ✅ |
| 4 | Validation (empty Day name → inline error, no PUT) | ✅ |
| 5 | Cancel closes editor without PUT, no mutation | ✅ |
| 6 | "View event planner →" CTA routes correctly | ✅ |
| 7 | "+ Add another day" appends row + auto-focuses | ✅ |
| 8 | Delete trash → inline "Remove? Yes/Cancel" confirmation | ✅ |
| 9 | Delete disabled when only 1 row remains | ✅ |
| 10 | Atomic Save: Add + Delete + Modify in one PUT (with Time reversal) | ✅ |

Test event used: `65a0bff005782a1dc21302c7` (Haldi day, 5 decorItems preserved through all save cycles).

## Known limitation (documented for follow-up)

The editor round-trips the full day subdocument (`decorItems`, `status`, `location`, `packages`, etc.) on every PUT — approximately 2.5KB per save with current data. This is because the backend's bulk `eventDays` update (sub-phase 1.5.6.1) does wholesale array replacement; stripping fields from the frontend payload would cause data loss.

**Concurrency hazard:** if admin updates a day's `status`/`location` between user dashboard load and user Save, user's save will overwrite the admin update. No known active conflict (admin tools don't currently race user edits on `eventDays[i]` between dashboard load and save).

Mitigation deferred to a future sub-phase (potential 1.5.6.3), which would either change the backend to field-level patch keyed on day `_id`, or strip non-editable fields from the frontend payload — backend change must come first.

## Deploy

Per batched deploy policy locked 12 May 2026: merge this PR to **staging only**. Main merge happens later in a batched PR carrying 1.5.5 frontend (already on staging) + 1.5.6.2 + 1.5.7 together, to minimize CloudFront invalidations.

## Notion

[Wedsy User App Project Master Index](https://www.notion.so/35a72ef954ed817ab83ad413b0866bd1)