### PR TITLE
Sub-phase 1.5.7: Welcome state + empty-flow wiring + B2 gate fix

### DIFF
--- a/components/profile/DesktopLayout.js
+++ b/components/profile/DesktopLayout.js
@@ -73,6 +73,7 @@ export default function DesktopLayout({
   onManageAllEvents,
   onMilestoneComplete,
   onInspirationTap,
+  rightRailMode = "full",
   children,
 }) {
   const monogram = deriveMonogram(event);
@@ -116,12 +117,14 @@ export default function DesktopLayout({
       <main className="lg:py-12 lg:px-14">{children}</main>
 
       <aside className="hidden lg:block bg-wedsy-ivory border-l border-wedsy-rose-100 px-7 py-14">
-        <NextUpCard
-          milestones={milestones}
-          eventId={eventId}
-          token={token}
-          onComplete={onMilestoneComplete}
-        />
+        {rightRailMode === "full" && (
+          <NextUpCard
+            milestones={milestones}
+            eventId={eventId}
+            token={token}
+            onComplete={onMilestoneComplete}
+          />
+        )}
         {inspiration && (
           <InspirationCard
             imageSrc={inspiration.imageSrc}
@@ -131,7 +134,7 @@ export default function DesktopLayout({
             onTap={onInspirationTap}
           />
         )}
-        <ThisWeekList milestones={milestones} />
+        {rightRailMode === "full" && <ThisWeekList milestones={milestones} />}
       </aside>
     </div>
   );

--- a/components/profile/EmptyStateStep1.js
+++ b/components/profile/EmptyStateStep1.js
@@ -8,10 +8,10 @@ const NAME_INPUT_CLASS =
 const NAME_LABEL_CLASS =
   "block text-[11px] tracking-[1px] uppercase text-wedsy-ink-3 font-medium mb-2";
 
-export default function EmptyStateStep1({ onContinue }) {
-  const [groomName, setGroomName] = useState("");
-  const [brideName, setBrideName] = useState("");
-  const [community, setCommunity] = useState("");
+export default function EmptyStateStep1({ onContinue, initialValues }) {
+  const [groomName, setGroomName] = useState(initialValues?.groomName || "");
+  const [brideName, setBrideName] = useState(initialValues?.brideName || "");
+  const [community, setCommunity] = useState(initialValues?.community || "");
 
   const canContinue =
     groomName.trim().length > 0 &&

--- a/components/profile/EmptyStateStep2.js
+++ b/components/profile/EmptyStateStep2.js
@@ -13,6 +13,8 @@ export default function EmptyStateStep2({ groomName, brideName, eventName, commu
   const [sameVenue, setSameVenue] = useState(true);
   const [commonVenue, setCommonVenue] = useState("");
   const [eventDays, setEventDays] = useState([blankDay()]);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
 
   const updateDay = (idx, patch) =>
     setEventDays((days) => days.map((d, i) => (i === idx ? { ...d, ...patch } : d)));
@@ -26,12 +28,19 @@ export default function EmptyStateStep2({ groomName, brideName, eventName, commu
     return eventDays.every((d) => d.venue.trim().length > 0);
   })();
 
-  const handleCreate = () => {
-    if (!isValid) return;
+  const handleCreate = async () => {
+    if (!isValid || submitting) return;
     const finalDays = sameVenue
       ? eventDays.map((d) => ({ ...d, venue: commonVenue.trim() }))
       : eventDays;
-    onComplete({ eventDays: finalDays });
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onComplete({ eventDays: finalDays });
+    } catch (err) {
+      setSubmitError(err?.message || "Couldn't create your event. Please try again.");
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -119,19 +128,25 @@ export default function EmptyStateStep2({ groomName, brideName, eventName, commu
         <button
           type="button"
           onClick={onBack}
-          className="flex-1 py-3 border border-wedsy-rose-400 text-wedsy-rose-600 text-[13px] tracking-[2px] uppercase font-medium hover:bg-wedsy-rose-50 transition-colors"
+          disabled={submitting}
+          className="flex-1 py-3 border border-wedsy-rose-400 text-wedsy-rose-600 text-[13px] tracking-[2px] uppercase font-medium hover:bg-wedsy-rose-50 transition-colors disabled:opacity-50"
         >
           Back
         </button>
         <button
           type="button"
-          disabled={!isValid}
+          disabled={!isValid || submitting}
           onClick={handleCreate}
           className="flex-1 py-3 bg-wedsy-rose-600 text-white text-[13px] tracking-[2px] uppercase font-medium disabled:bg-wedsy-ink-3 disabled:cursor-not-allowed transition-colors"
         >
-          Create
+          {submitting ? "Creating…" : "Create"}
         </button>
       </div>
+      {submitError && (
+        <p className="mt-4 font-serif italic text-[12px] text-wedsy-burgundy text-center">
+          {submitError}
+        </p>
+      )}
     </section>
   );
 }

--- a/components/profile/EmptyStateWelcome.js
+++ b/components/profile/EmptyStateWelcome.js
@@ -1,0 +1,21 @@
+export default function EmptyStateWelcome({ onCreateEvent }) {
+  return (
+    <section className="text-center pt-16 pb-12 px-6 lg:max-w-[560px] lg:mx-auto lg:py-24">
+      <p className="wedsy-eyebrow">WELCOME</p>
+      <h1 className="wedsy-title text-[36px] leading-[1.1] mt-3 text-wedsy-ink lg:text-[44px]">
+        Your planning home, ready to begin
+      </h1>
+      <div className="wedsy-ornament-divider my-6 mx-auto"></div>
+      <p className="wedsy-italic-em text-[15px] mt-2 lg:text-[16px] text-wedsy-ink-2">
+        Create your event to unlock your timeline, vendor tracker, and planning console.
+      </p>
+      <button
+        type="button"
+        onClick={onCreateEvent}
+        className="mt-10 w-full py-3 bg-wedsy-rose-600 text-white text-[13px] tracking-[2px] uppercase font-medium hover:bg-wedsy-burgundy transition-colors lg:w-auto lg:px-12 lg:mx-auto lg:block"
+      >
+        Create your event →
+      </button>
+    </section>
+  );
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -2,6 +2,7 @@ import AccountList from "@/components/profile/AccountList";
 import DesktopLayout from "@/components/profile/DesktopLayout";
 import EmptyStateStep1 from "@/components/profile/EmptyStateStep1";
 import EmptyStateStep2 from "@/components/profile/EmptyStateStep2";
+import EmptyStateWelcome from "@/components/profile/EmptyStateWelcome";
 import EventDaysCarousel from "@/components/profile/EventDaysCarousel";
 import EventDaysEditor from "@/components/profile/EventDaysEditor";
 import InspirationCard from "@/components/profile/InspirationCard";
@@ -10,11 +11,13 @@ import StatsGrid from "@/components/profile/StatsGrid";
 import TimelineCanvas from "@/components/profile/TimelineCanvas";
 import TimelineCard from "@/components/profile/TimelineCard";
 import useProfileData from "@/hooks/useProfileData";
-import { regenerateTimeline } from "@/utils/api/wedding-timeline";
+import { createEvent, regenerateTimeline, updateEvent } from "@/utils/api/wedding-timeline";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+
+const CREATION_DRAFT_KEY = "wedsy.creationDraft";
 
 const MOCK_STATS = [
   { label: "Days to wedding", value: 11 },
@@ -74,6 +77,16 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorFocusIndex, setEditorFocusIndex] = useState(null);
+  const [creationDraft, setCreationDraft] = useState(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      const stored = window.sessionStorage.getItem(CREATION_DRAFT_KEY);
+      return stored ? JSON.parse(stored) : null;
+    } catch {
+      return null;
+    }
+  });
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     CheckLogin();
@@ -107,7 +120,7 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
     refetchEvent,
   } = useProfileData({ token, selectedEventId });
 
-  if (!user?.name) {
+  if (!user?.phone) {
     return (
       <div className="wedsy-screen-container">
         <p className="wedsy-subtitle" style={{ padding: "60px 24px", textAlign: "center" }}>Loading…</p>
@@ -133,6 +146,62 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
   const handleSwitchEvent = (eventId) => router.push({ pathname: "/profile", query: { eventId } }, undefined, { shallow: true });
   const handleManageAll = () => router.push("/event");
 
+  const handleWelcomeCreateEvent = () => router.push("/profile?state=empty1");
+
+  const handleStep1Continue = (data) => {
+    const nextDraft = { ...(creationDraft || {}), ...data };
+    try {
+      window.sessionStorage.setItem(CREATION_DRAFT_KEY, JSON.stringify(nextDraft));
+    } catch {}
+    setCreationDraft(nextDraft);
+    router.push("/profile?state=empty2");
+  };
+
+  const handleStep2Back = () => router.push("/profile?state=empty1");
+
+  const handleStep2Complete = async (data) => {
+    if (!token) throw new Error("Not authenticated");
+    if (!creationDraft) throw new Error("Missing event details");
+    const days = data.eventDays || [];
+    if (!days.length) throw new Error("No event days");
+
+    setCreating(true);
+    try {
+      const firstDay = days[0];
+      const postPayload = {
+        groomName: creationDraft.groomName,
+        brideName: creationDraft.brideName,
+        community: creationDraft.community,
+        eventDay: firstDay.name,
+        date: firstDay.date,
+        time: firstDay.time,
+        venue: firstDay.venue,
+      };
+      const { data: postData, error: postError } = await createEvent(postPayload, token);
+      if (postError || !postData?._id) {
+        throw new Error("Couldn't create your event. Please try again.");
+      }
+      const newEventId = postData._id;
+
+      if (days.length > 1) {
+        const { error: putError } = await updateEvent(newEventId, { eventDays: days }, token);
+        if (putError) {
+          throw new Error("Event created but couldn't save all days. Please try again.");
+        }
+      }
+
+      try {
+        window.sessionStorage.removeItem(CREATION_DRAFT_KEY);
+      } catch {}
+      setCreationDraft(null);
+      setCreating(false);
+      router.push(`/profile?eventId=${newEventId}`);
+    } catch (err) {
+      setCreating(false);
+      throw err;
+    }
+  };
+
   return (
     <>
       <Head>
@@ -143,19 +212,42 @@ export default function Profile({ user, userLoggedIn, CheckLogin, setOpenLoginMo
           <p className="wedsy-subtitle" style={{ padding: "60px 24px", textAlign: "center" }}>Loading…</p>
         ) : eventError ? (
           <p className="font-serif italic text-[13px] text-wedsy-ink-3 text-center" style={{ padding: "60px 24px" }}>Unable to load your wedding. Please reload.</p>
-        ) : explicitEmptyState === "empty1" || shouldShowEmpty1(event, eventLoading) ? (
+        ) : explicitEmptyState === "empty1" ? (
           <EmptyStateStep1
-            onContinue={(data) => console.log("Mock create event step 1:", data)}
+            onContinue={handleStep1Continue}
+            initialValues={creationDraft}
           />
-        ) : explicitEmptyState === "empty2" || shouldShowEmpty2(event, eventLoading) ? (
+        ) : explicitEmptyState === "empty2" ? (
+          <EmptyStateStep2
+            groomName={creationDraft?.groomName || event?.groomName}
+            brideName={creationDraft?.brideName || event?.brideName}
+            eventName={event?.name || "Your wedding"}
+            community={creationDraft?.community || event?.community || "Hindu"}
+            onBack={handleStep2Back}
+            onComplete={handleStep2Complete}
+          />
+        ) : shouldShowEmpty2(event, eventLoading) ? (
           <EmptyStateStep2
             groomName={event.groomName}
             brideName={event.brideName}
             eventName={event.name || "Your wedding"}
             community={event.community || "Hindu"}
-            onBack={() => console.log("Mock back from step 2")}
-            onComplete={(data) => console.log("Mock complete event days:", data)}
+            onBack={handleStep2Back}
+            onComplete={handleStep2Complete}
           />
+        ) : shouldShowEmpty1(event, eventLoading) ? (
+          <DesktopLayout
+            event={null}
+            events={[]}
+            milestones={[]}
+            inspiration={MOCK_INSPIRATION}
+            onCreateNewEvent={handleCreateNewEvent}
+            onManageAllEvents={handleManageAll}
+            onInspirationTap={() => console.log("Mock inspiration tap")}
+            rightRailMode="minimal"
+          >
+            <EmptyStateWelcome onCreateEvent={handleWelcomeCreateEvent} />
+          </DesktopLayout>
         ) : (
           <DesktopLayout event={event} events={events} milestones={milestones} eventId={event?._id} token={token} inspiration={MOCK_INSPIRATION} onSwitchEvent={handleSwitchEvent} onCreateNewEvent={handleCreateNewEvent} onManageAllEvents={handleManageAll} onMilestoneComplete={refetchMilestones} onInspirationTap={() => console.log("Mock inspiration tap")}>
             <ProfileHero coupleName={deriveCoupleName(event)} weddingDate={deriveWeddingDate(event)} eventDayCount={event.eventDays?.length || 0} eventDayNames={deriveEventDayNames(event)} />

--- a/utils/api/wedding-timeline.js
+++ b/utils/api/wedding-timeline.js
@@ -81,3 +81,7 @@ export async function markMilestoneComplete(eventId, milestoneId, token) {
 export async function updateEvent(eventId, payload, token) {
   return authedRequest("PUT", `/event/${eventId}`, token, payload);
 }
+
+export async function createEvent(payload, token) {
+  return authedRequest("POST", "/event", token, payload);
+}


### PR DESCRIPTION
## Summary

Adds the welcome state for logged-in users with no event, wires the three previously-stubbed empty-flow callbacks so end-to-end event creation works, and bundles the B2 gate fix from the auth audit (without which the welcome state is unreachable).

## Changes

| File | Change |
|---|---|
| `components/profile/EmptyStateWelcome.js` | NEW — welcome card |
| `components/profile/DesktopLayout.js` | `+rightRailMode` prop |
| `components/profile/EmptyStateStep1.js` | `+initialValues` prop for Back pre-fill |
| `components/profile/EmptyStateStep2.js` | submitting/error state, async create |
| `pages/profile.js` | welcome branching, 3 callbacks, Path A POST+PUT, B2 fix, sessionStorage draft |
| `utils/api/wedding-timeline.js` | `+createEvent` helper |

6 files, +159 / -24.

## Behavior

- **Welcome state** renders on `/profile` for logged-in users with no event — inside DesktopLayout with `rightRailMode="minimal"` (Inspiration card only).
- **Empty-flow wiring** — Step 1 Continue → Step 2 (draft preserved); Step 2 Back → Step 1 (form pre-filled); Step 2 Create → Path A two-call: `POST /event` flat-shaped with day[0], then `PUT /event/:id` with full `eventDays` array if multi-day.
- **B2 fix** — `profile.js` render gate changed `!user?.name` → `!user?.phone`. Pre-fix, any user with empty `name` (e.g. India auto-create accounts per auth audit) was stuck on infinite Loading.
- **creationDraft persistence fix** — `_app.js` has `key={router.asPath}` on a framer-motion wrapper, which fully remounts Profile on every `?state=` change and resets React state. `creationDraft` is now backed by `sessionStorage` so it survives the remount. `_app.js` was NOT modified.

## Verification

Manual verification against `prod.server.wedsy.in` on Chrome 1440px, account `+916364938428` (empty-name account — also verifies the B2 fix). 10-test plan all passed. Multi-day creation (Test 6) verified visually, no DB-level confirmation. creationDraft persistence bug was found during verification and fixed within this PR.

## Deploy

Per batched deploy policy: merge to **staging only**. Main merge happens later in the batched PR carrying 1.5.5 frontend + 1.5.6.2 + 1.5.7.

## Notion

[Master Index](https://www.notion.so/35a72ef954ed817ab83ad413b0866bd1) · [Auth Audit](https://www.notion.so/35f72ef954ed8167aabffcd117163451)