### PR TITLE
Fix: Remove hardcoded localhost URLs from prod paths (sub-phase 1.5.11)

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -4275,7 +4275,7 @@ Tell us about your Wedding
 
 export async function getServerSideProps(context) {
   try {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8090';
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
     
     if (!apiUrl) {
       console.warn("NEXT_PUBLIC_API_URL not configured; returning empty packages list");

--- a/pages/makeup-and-beauty/artists/[vendorId].js
+++ b/pages/makeup-and-beauty/artists/[vendorId].js
@@ -107,9 +107,8 @@ function MakeupAndBeauty({ userLoggedIn, setOpenLoginModalv2, setSource, initial
   useEffect(() => {
     const generateShortUrl = async () => {
       try {
-        //change the localhost to your domain name when deploying
         const response = await fetch(
-          `https://tinyurl.com/api-create.php?url=http://localhost:3000/makeup-and-beauty/artists/${vendorId}`
+          `https://tinyurl.com/api-create.php?url=https://wedsy.in/makeup-and-beauty/artists/${vendorId}`
         );
         const shortLink = await response.text();
         setShortUrl(shortLink + "#reviews");


### PR DESCRIPTION
Sub-phase 1.5.11 — production hygiene. Removes two hardcoded localhost URLs that shipped to production.

USR-PG-002 (HIGH) — pages/index.js getServerSideProps had `process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8090'`. The fallback ran in production SSR on a missing env var, silently hitting localhost. Removed the fallback; the existing if(!apiUrl) guard is now reachable and degrades gracefully to packages:null.

USR-PG-004 (HIGH) — pages/makeup-and-beauty/artists/[vendorId].js built its TinyURL share link from a localhost:3000 URL, producing short links unusable by anyone but a developer. Now uses https://wedsy.in, consistent with the existing catch-block fallback on line 118.

Files: pages/index.js, pages/makeup-and-beauty/artists/[vendorId].js (2 files, +2 −3)

Tested:
- npm run build clean
- Homepage SSR verified against prod.server.wedsy.in — packages prop populated (8 items), no localhost fetch, no missing-env warning
- grep for "localhost:" across pages/components/utils/hooks returns zero