### PR TITLE
Feature: Coming-soon gate for /decor and /wedding-store

### DIFF
--- a/components/ComingSoonPage.js
+++ b/components/ComingSoonPage.js
@@ -1,0 +1,45 @@
+/**
+ * Public-facing "coming soon" gate shown when a page is hidden from
+ * scraping. Internal team bypasses via the server-side preview key.
+ *
+ * `pageName` ("decor" | "wedding-store") is accepted for future
+ * per-page copy; v1 copy is identical for both.
+ */
+export default function ComingSoonPage({ pageName }) {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-wedsy-ivory px-5 sm:px-6">
+      <section className="w-full max-w-[600px] mx-auto text-center">
+        <p className="wedsy-eyebrow">COMING SOON</p>
+
+        <h1 className="wedsy-title text-[34px] leading-[1.15] mt-4 text-wedsy-ink sm:text-[44px]">
+          Something beautiful is coming
+        </h1>
+
+        <div className="wedsy-ornament-divider my-7 mx-auto"></div>
+
+        <p className="wedsy-italic-em text-[17px] leading-[1.5] mt-2 sm:text-[19px]">
+          {"We're curating Bangalore's most stunning wedding collection."}
+        </p>
+
+        <p className="wedsy-subtitle mt-6 text-[14px]">Launching soon.</p>
+
+        <p className="mt-12 font-sans text-[12px] tracking-[0.3px] text-wedsy-ink-3">
+          Questions? Reach us at{" "}
+          <a
+            href="mailto:hello@wedsy.in"
+            className="text-wedsy-ink-3 no-underline hover:underline"
+          >
+            hello@wedsy.in
+          </a>{" "}
+          or{" "}
+          <a
+            href="tel:+916364849765"
+            className="text-wedsy-ink-3 no-underline hover:underline"
+          >
+            +91 63648 49765
+          </a>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/pages/decor/index.js
+++ b/pages/decor/index.js
@@ -1,4 +1,5 @@
 import Breadcrumbs from "@/components/Breadcrumbs";
+import ComingSoonPage from "@/components/ComingSoonPage";
 import DecorCard from "@/components/cards/DecorCard";
 import { processMobileNumber } from "@/utils/phoneNumber";
 import { trimTitle, trimDescription, OG_IMAGES } from "@/utils/seo";
@@ -18,6 +19,7 @@ function Decor({
   user,
   spotlightList = [],
   allCategories = [],
+  showComingSoon = false,
 }) {
   const [spotlightIndex, setSpotlightIndex] = useState(0);
   const spotlightRef = useRef(null);
@@ -491,6 +493,10 @@ function Decor({
       pbTimersRef.current = [];
     };
   }, []);
+
+  if (showComingSoon) {
+    return <ComingSoonPage pageName="decor" />;
+  }
 
   return (
     <div className="bg-[#F4F4F4] min-h-screen w-full">
@@ -2058,6 +2064,12 @@ function Decor({
 }
 
 export async function getServerSideProps(context) {
+  const previewKey = process.env.PREVIEW_KEY;
+  const isPreview = context.query.preview === previewKey;
+  if (!isPreview) {
+    return { props: { showComingSoon: true } };
+  }
+
   try {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;
     if (!apiUrl) {

--- a/pages/wedding-store/index.js
+++ b/pages/wedding-store/index.js
@@ -1,4 +1,5 @@
 import Breadcrumbs from "@/components/Breadcrumbs";
+import ComingSoonPage from "@/components/ComingSoonPage";
 import DecorCard from "@/components/cards/DecorCard";
 import DecorDisclaimer from "@/components/marquee/DecorDisclaimer";
 import { trimTitle, trimDescription, OG_IMAGES } from "@/utils/seo";
@@ -8,7 +9,7 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { BsInstagram } from "react-icons/bs";
 
-function WeddingStore({ bestSeller, popular, spotlightList, categoryList }) {
+function WeddingStore({ bestSeller, popular, spotlightList, categoryList, showComingSoon = false }) {
   const [spotlightIndex, setSpotlightIndex] = useState(0);
   const spotlightRef = useRef(null);
   const spotlightHorizontalRef = useRef(null);
@@ -114,6 +115,10 @@ function WeddingStore({ bestSeller, popular, spotlightList, categoryList }) {
       }
     ]
   };
+
+  if (showComingSoon) {
+    return <ComingSoonPage pageName="wedding-store" />;
+  }
 
   return (
     <>
@@ -460,6 +465,12 @@ function WeddingStore({ bestSeller, popular, spotlightList, categoryList }) {
 }
 
 export async function getServerSideProps(context) {
+  const previewKey = process.env.PREVIEW_KEY;
+  const isPreview = context.query.preview === previewKey;
+  if (!isPreview) {
+    return { props: { showComingSoon: true } };
+  }
+
   try {
     const bestSellerResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_URL}/decor?label=bestSeller`


### PR DESCRIPTION
Adds a server-side preview-key gate on /decor and /wedding-store
index pages. Public visitors see a Coming Soon page; internal team
bypasses via ?preview=<key>.

- Subroutes intentionally not gated (block catalog scraping is the
  real goal; subroute access is acceptable as a tradeoff for simpler
  implementation)
- PREVIEW_KEY is server-side only (NOT NEXT_PUBLIC_) so the key never
  reaches the browser bundle
- Build clean, types pass, lint passes
- Visual verification done locally on all 4 URLs

## What's NOT in this PR (intentional)
- No email capture / lead form (separate sub-phase)
- No subroute gating (separate decision)
- Production env var (PREVIEW_KEY) needs to be set in the production
  build environment before main merge — Rohaan to handle

## Files
- components/ComingSoonPage.js (new, ~45 lines)
- pages/decor/index.js (+12 lines)
- pages/wedding-store/index.js (+13 lines, -1 line)

## Test plan
1. Merge this PR to staging
2. Verify staging build passes
3. Set PREVIEW_KEY in production build environment
4. Merge staging → main
5. CloudFront propagates
6. Visual check on wedsy.in

🤖 Generated with [Claude Code](https://claude.com/claude-code)